### PR TITLE
From one GameEngine to many GameSessions

### DIFF
--- a/Attt_LocalEngine_Kotlin/build.gradle.kts
+++ b/Attt_LocalEngine_Kotlin/build.gradle.kts
@@ -10,12 +10,14 @@ repositories {
 }
 
 dependencies {
-    testImplementation("org.jetbrains.kotlin:kotlin-test")
+//    testImplementation("org.jetbrains.kotlin:kotlin-test")
+    testImplementation(kotlin("test"))
 }
 
 tasks.test {
     useJUnitPlatform()
 }
+
 kotlin {
     jvmToolchain(21)
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameEngine.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameEngine.kt
@@ -11,7 +11,7 @@ import utilities.Log
  * a game session can be started & finished, each time new to be clear from any possible remains.
  */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
-internal object GameEngine : AtttGame {
+class GameEngine(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
 
     // let's not consume RAM with game objects until the game is not yet started - that's why these are nullable
     internal var gameField: GameField? = null
@@ -20,18 +20,24 @@ internal object GameEngine : AtttGame {
     // this is a part of inner game logic - it should be used only internally, for now there's no need to show it to a client
     internal var activePlayer: AtttPlayer = Player.None
 
+    init {
+        gameField = GameField(desiredFieldSize)
+        gameRules = GameRules(desiredMaxLineLength)
+        prepareNextPlayer()
+    }
+
     // -------
     // region PUBLIC API
 
     /**
      * create & provide the UI with a new game field, adjustability starts here - in the parameters
      */
-    override fun prepareGame(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttPlayer {
-        if (gameExists()) finish() // any previous game should be stopped before a new one is launched on this GameEngine
-        gameField = GameField(desiredFieldSize)
-        gameRules = GameRules(desiredMaxLineLength)
-        return prepareNextPlayer() // absolutely necessary to have this invocation here - it prepares the first player's move
-    }
+//    override fun prepareGame(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttPlayer {
+//        if (gameExists()) finish() // any previous game should be stopped before a new one is launched on this GameEngine
+//        gameField = GameField(desiredFieldSize)
+//        gameRules = GameRules(desiredMaxLineLength)
+//        return prepareNextPlayer() // absolutely necessary to have this invocation here - it prepares the first player's move
+//    }
 
     /**
      * stop right now and clear all occupied resources, this game session gets impossible for any use

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameField.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameField.kt
@@ -48,11 +48,6 @@ internal class GameField(
      */
     internal fun getCurrentMarkAt(x: Int, y: Int): AtttPlayer? = theMap[Coordinates(x, y)]
 
-    internal fun clear() {
-        theMap.clear()
-        sideLength = -1 // intentionally placing incorrect value to prevent from using this object again
-    }
-
     /**
      * ensures that the game field has correct size & is clear, so it is safe to use it for a new game
      */

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameRules.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameRules.kt
@@ -22,12 +22,6 @@ internal class GameRules(
         else if (winningLength < MIN_WINNING_LINE_LENGTH) winningLength = MIN_WINNING_LINE_LENGTH
     }
 
-    internal fun clear() {
-        maxLines.clear()
-        theWinner = null
-        winningLength = -1
-    }
-
     internal fun isGameWon(): Boolean = theWinner != null
 
     internal fun getWinner(): AtttPlayer? = theWinner

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -11,7 +11,7 @@ import utilities.Log
  * a game session can be started & finished, each time new to be clear from any possible remains.
  */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
-class GameEngine(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
+class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
 
     // let's not consume RAM with game objects until the game is not yet started - that's why these are nullable
     internal var gameField: GameField? = null

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -27,17 +27,6 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
     // region PUBLIC API
 
     /**
-     * stop right now and clear all occupied resources, this game session gets impossible for any use
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
-    override fun finish() {
-        Log.pl("the game is finished in the given state: ${gameField.prepareForPrintingIn2d()}")
-        gameField.clear()
-        gameRules.clear()
-        activePlayer = Player.None
-    }
-
-    /**
      * the same as makeMove(...) - this reduction is made for convenience as this method is the most frequently used
      */
     override fun mm(x: Int, y: Int) = makeMove(x, y)

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -13,42 +13,27 @@ import utilities.Log
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
 
-    // let's not consume RAM with game objects until the game is not yet started - that's why these are nullable
-    internal var gameField: GameField? = null
-    private var gameRules: GameRules? = null
+    internal var gameField: GameField = GameField(desiredFieldSize)
+    private var gameRules: GameRules = GameRules(desiredMaxLineLength)
 
     // this is a part of inner game logic - it should be used only internally, for now there's no need to show it to a client
     internal var activePlayer: AtttPlayer = Player.None
 
     init {
-        gameField = GameField(desiredFieldSize)
-        gameRules = GameRules(desiredMaxLineLength)
-        prepareNextPlayer()
+        prepareNextPlayer() // this invocation sets the activePlayer to the first Player among others
     }
 
     // -------
     // region PUBLIC API
 
     /**
-     * create & provide the UI with a new game field, adjustability starts here - in the parameters
-     */
-//    override fun prepareGame(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttPlayer {
-//        if (gameExists()) finish() // any previous game should be stopped before a new one is launched on this GameEngine
-//        gameField = GameField(desiredFieldSize)
-//        gameRules = GameRules(desiredMaxLineLength)
-//        return prepareNextPlayer() // absolutely necessary to have this invocation here - it prepares the first player's move
-//    }
-
-    /**
      * stop right now and clear all occupied resources, this game session gets impossible for any use
      */
     @Suppress("MemberVisibilityCanBePrivate")
     override fun finish() {
-        Log.pl("the game is finished in the given state: ${gameField?.prepareForPrintingIn2d()}")
-        gameField?.clear()
-        gameField = null
-        gameRules?.clear()
-        gameRules = null
+        Log.pl("the game is finished in the given state: ${gameField.prepareForPrintingIn2d()}")
+        gameField.clear()
+        gameRules.clear()
         activePlayer = Player.None
     }
 
@@ -61,7 +46,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
      * this is the only way for a client to make progress in the game.
      * there is no need to set active player - it's detected & returned automatically, like the next cartridge in revolver.
      */
-    override fun makeMove(x: Int, y: Int): AtttPlayer = if (gameField?.isCorrectPosition(x, y) == true) {
+    override fun makeMove(x: Int, y: Int): AtttPlayer = if (gameField.isCorrectPosition(x, y)) {
         makeMove(Coordinates(x, y))
     } else {
         activePlayer
@@ -71,54 +56,47 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
      * this function is actually the only place for making moves and thus changing the game field
      */
     internal fun makeMove(where: Coordinates, what: AtttPlayer = activePlayer): AtttPlayer =
-        gameField?.let { field ->
-            if (field.placeNewMark(where, what)) {
-                // analyze this new dot & detect if it creates or changes any lines in all possible directions
-                val existingLineDirections = field.detectAllExistingLineDirectionsFromThePlacedMark(where)
-                val maxLengthForThisMove = existingLineDirections.maxOfOrNull { lineDirection ->
-                    field.measureFullLengthForExistingLineFrom(where, lineDirection)
-                }
-                Log.pl("makeMove: maxLength for this move of player $what is: $maxLengthForThisMove")
-                maxLengthForThisMove?.let {
-                    (what as Player).tryToSetMaxLineLength(it) // this cast is secure as Player is direct inheritor to AtttPlayer
-                    updateGameScore(what, it)
-                }
-                return prepareNextPlayer() // todo: check all possible & impossible cases of forcing moves by different players
-            } else {
-                return what
+        if (gameField.placeNewMark(where, what)) {
+            // analyze this new dot & detect if it creates or changes any lines in all possible directions
+            val existingLineDirections = gameField.detectAllExistingLineDirectionsFromThePlacedMark(where)
+            val maxLengthForThisMove = existingLineDirections.maxOfOrNull { lineDirection ->
+                gameField.measureFullLengthForExistingLineFrom(where, lineDirection)
             }
-        } ?: Player.None // when there is no field - there should be no player
+            Log.pl("makeMove: maxLength for this move of player $what is: $maxLengthForThisMove")
+            maxLengthForThisMove?.let {
+                (what as Player).tryToSetMaxLineLength(it) // this cast is secure as Player is direct inheritor to AtttPlayer
+                updateGameScore(what, it)
+            }
+            prepareNextPlayer()
+        } else {
+            what
+        }
 
     /**
      * a client might want to know the currently leading player at any time during the game
      */
-    override fun getLeader(): AtttPlayer = gameRules?.getLeadingPlayer() ?: Player.None
+    override fun getLeader(): AtttPlayer = gameRules.getLeadingPlayer()
 
     /**
      * there can be only one winner - Player.None is returned until the winner not yet detected
      */
-    override fun getWinner(): AtttPlayer = gameRules?.getWinner() ?: Player.None
+    override fun getWinner(): AtttPlayer = gameRules.getWinner() ?: Player.None
 
     /**
      * after the winner is detected there is no way to modify the game field, so the game state is preserved
      */
-    override fun isGameWon() = gameRules?.isGameWon() == true
+    override fun isGameWon() = gameRules.isGameWon()
 
     /**
      * prints the current state of the game in 2d on console
      */
     override fun printCurrentFieldIn2d() {
-        println(gameField?.prepareForPrintingIn2d())
+        println(gameField.prepareForPrintingIn2d())
     }
 
     // endregion PUBLIC API
     // --------
     // region ALL PRIVATE
-
-    /**
-     * if a game session exists - than we have an actively running game which can have a winner or not
-     */
-    private fun gameExists() = gameField != null && gameRules != null
 
     /**
      * sets the currently active player, for which a move will be made & returns the player for the next move
@@ -132,11 +110,9 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
      * gameRules data is updated only here
      */
     private fun updateGameScore(whichPlayer: AtttPlayer, detectedLineLength: Int) {
-        gameRules?.let { rules ->
-            rules.updatePlayerScore(whichPlayer, detectedLineLength)
-            if (rules.isGameWon()) {
-                Log.pl("player ${rules.getWinner()} wins with detectedLineLength: $detectedLineLength")
-            }
+        gameRules.updatePlayerScore(whichPlayer, detectedLineLength)
+        if (gameRules.isGameWon()) {
+            Log.pl("player ${gameRules.getWinner()} wins with detectedLineLength: $detectedLineLength")
         }
     }
 

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
@@ -23,8 +23,6 @@ interface AtttGame {
 
     fun printCurrentFieldIn2d()
 
-    fun finish()
-
     companion object {
         /**
          * create AtttGame instance & provide the UI with a new game field, adjustability happens here - in the parameters

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
@@ -11,8 +11,6 @@ interface AtttPlayer {
 
 interface AtttGame {
 
-//    fun prepareGame(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttPlayer
-
     fun mm(x: Int, y: Int): AtttPlayer
 
     fun makeMove(x: Int, y: Int): AtttPlayer
@@ -28,6 +26,9 @@ interface AtttGame {
     fun finish()
 
     companion object {
+        /**
+         * create AtttGame instance & provide the UI with a new game field, adjustability happens here - in the parameters
+         */
         fun create(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttGame =
             GameSession(desiredFieldSize, desiredMaxLineLength)
     }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
@@ -1,6 +1,6 @@
 package publicApi
 
-import logic.GameEngine
+import logic.GameSession
 
 interface AtttPlayer {
 
@@ -29,6 +29,6 @@ interface AtttGame {
 
     companion object {
         fun create(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttGame =
-            GameEngine(desiredFieldSize, desiredMaxLineLength)
+            GameSession(desiredFieldSize, desiredMaxLineLength)
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
@@ -11,7 +11,7 @@ interface AtttPlayer {
 
 interface AtttGame {
 
-    fun prepareGame(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttPlayer
+//    fun prepareGame(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttPlayer
 
     fun mm(x: Int, y: Int): AtttPlayer
 
@@ -28,6 +28,7 @@ interface AtttGame {
     fun finish()
 
     companion object {
-        fun create(): AtttGame = GameEngine
+        fun create(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttGame =
+            GameEngine(desiredFieldSize, desiredMaxLineLength)
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
@@ -1,6 +1,6 @@
 import elements.Coordinates
 import elements.Player
-import logic.GameEngine
+import logic.GameSession
 import utilities.Log
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -28,7 +28,7 @@ class InternalApiTesting {
     // this test was provided by Matt Tucker - https://github.com/tuck182 - many thanks for finding a serious bug!
     @Test
     fun test3x3FieldWithMultiplePossibleLines() { // test name is left as it was in the pull-request
-        val game = GameEngine(3, 3)
+        val game = GameSession(3, 3)
 
         // .Xx
         // .xo

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
@@ -1,7 +1,6 @@
 import elements.Coordinates
 import elements.Player
 import logic.GameEngine
-import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -15,67 +14,69 @@ class InternalApiTesting {
         Log.switch(true)
     }
 
-    @Test
-    fun havingUnpreparedField_aPlayerTriesToMakeMove_noMoveIsMadeOnUnpreparedField() {
-        val game = AtttGame.create()
-        (game as GameEngine).makeMove(Coordinates(0, 0))
-        assertEquals(Player.None, game.getLeader())
-        assertEquals(0, game.getLeader().getMaxLineLength())
-        // so it's impossible to play game BEFORE prepare() is invoked
-    }
+    /*
+        @Test
+        fun havingUnpreparedField_aPlayerTriesToMakeMove_noMoveIsMadeOnUnpreparedField() {
+            val game = AtttGame.create()
+            (game as GameEngine).makeMove(Coordinates(0, 0))
+            assertEquals(Player.None, game.getLeader())
+            assertEquals(0, game.getLeader().getMaxLineLength())
+            // so it's impossible to play game BEFORE prepare() is invoked
+        }
+    */
 
     // this test was provided by Matt Tucker - https://github.com/tuck182 - many thanks for finding a serious bug!
     @Test
     fun test3x3FieldWithMultiplePossibleLines() { // test name is left as it was in the pull-request
-        GameEngine.prepareGame(3, 3)
+        val game = GameEngine(3, 3)
 
         // .Xx
         // .xo
         // oxo
 
-        GameEngine.makeMove(Coordinates(1, 1), Player.A)
-        GameEngine.makeMove(Coordinates(2, 1), Player.B)
-        GameEngine.makeMove(Coordinates(2, 0), Player.A)
-        GameEngine.makeMove(Coordinates(0, 2), Player.B)
-        GameEngine.makeMove(Coordinates(1, 2), Player.A)
-        GameEngine.makeMove(Coordinates(2, 2), Player.B)
-        GameEngine.makeMove(Coordinates(1, 0), Player.A) // here A wins and anyway the next possible player is B
+        game.makeMove(Coordinates(1, 1), Player.A)
+        game.makeMove(Coordinates(2, 1), Player.B)
+        game.makeMove(Coordinates(2, 0), Player.A)
+        game.makeMove(Coordinates(0, 2), Player.B)
+        game.makeMove(Coordinates(1, 2), Player.A)
+        game.makeMove(Coordinates(2, 2), Player.B)
+        game.makeMove(Coordinates(1, 0), Player.A) // here A wins and anyway the next possible player is B
 
 //        assertFalse(GameEngine.isActive(), "Game should have been won") -> no more relevant as the API was changed
-        assertTrue(GameEngine.isGameWon(), "Game should have been won")
+        assertTrue(game.isGameWon(), "Game should have been won")
         // Would be nice to be able to do this:
         // assertEquals(AtttPlayer.A, AtttEngine.getWinner())
         // -> and yes, this is done:
-        assertEquals(Player.A, GameEngine.getWinner())
+        assertEquals(Player.A, game.getWinner())
     }
 
     @Test
     fun having3x3Field_realSimulation2PlayersMovesMade_victoryConditionIsCorrect() {
-        prepareClassic3x3GameField()
-        GameEngine.makeMove(Coordinates(0, 0))
-        GameEngine.makeMove(Coordinates(1, 0))
-        GameEngine.makeMove(Coordinates(2, 0))
-        GameEngine.makeMove(Coordinates(1, 1))
-        GameEngine.makeMove(Coordinates(2, 1))
-        GameEngine.makeMove(Coordinates(1, 2))
+        val game = prepareClassic3x3GameField()
+        game.makeMove(Coordinates(0, 0))
+        game.makeMove(Coordinates(1, 0))
+        game.makeMove(Coordinates(2, 0))
+        game.makeMove(Coordinates(1, 1))
+        game.makeMove(Coordinates(2, 1))
+        game.makeMove(Coordinates(1, 2))
         // gameField & winning message for player B is printed in the console
-        assertEquals(Player.B, GameEngine.getWinner())
-        assertEquals(Player.A, GameEngine.activePlayer) // game is ready for the next potential move in any case
-        assertEquals(3, GameEngine.getWinner().getMaxLineLength())
+        assertEquals(Player.B, game.getWinner())
+        assertEquals(Player.A, game.activePlayer) // game is ready for the next potential move in any case
+        assertEquals(3, game.getWinner().getMaxLineLength())
     }
 
     @Test
     fun having3x3Field_realSimulation2PlayersShortenedMovesMade_victoryConditionIsCorrect() {
-        prepareClassic3x3GameField()
-        GameEngine.makeMove(0, 0)
-        GameEngine.makeMove(1, 0)
-        GameEngine.makeMove(2, 0)
-        GameEngine.makeMove(1, 1)
-        GameEngine.makeMove(2, 1)
-        GameEngine.makeMove(1, 2)
+        val game = prepareClassic3x3GameField()
+        game.makeMove(0, 0)
+        game.makeMove(1, 0)
+        game.makeMove(2, 0)
+        game.makeMove(1, 1)
+        game.makeMove(2, 1)
+        game.makeMove(1, 2)
         // gameField & winning message for player B is printed in the console
-        assertEquals(Player.B, GameEngine.getWinner())
-        assertEquals(Player.A, GameEngine.activePlayer) // game is ready for the next potential move in any case
-        assertEquals(3, GameEngine.getWinner().getMaxLineLength())
+        assertEquals(Player.B, game.getWinner())
+        assertEquals(Player.A, game.activePlayer) // game is ready for the next potential move in any case
+        assertEquals(3, game.getWinner().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -1,6 +1,6 @@
 import elements.*
 import logic.GameEngine
-import org.junit.jupiter.api.AfterEach
+import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -14,83 +14,78 @@ class InternalElementsTesting {
         Log.switch(true)
     }
 
-    @AfterEach
-    fun clearGameField() {
-        GameEngine.finish()
-    }
-
     // region GameEngine preparation
 
     @Test
     fun gameIsNotStarted_classic3x3GameIsCreated_classic3x3GameFieldIsReady() {
-        prepareClassic3x3GameField()
-        assertTrue(isGameFieldReady())
+        val game = prepareClassic3x3GameField()
+        assertTrue(isGameFieldReady(game.gameField))
     }
 
     @Test
     fun gameIsNotStarted_gameFieldOfAnyCorrectSizeIsCreated_gameFieldWithSpecifiedSizeIsReady() {
-        GameEngine.prepareGame(7, 5)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(7, getGameFieldSideLength())
+        val game = GameEngine(7, 5)
+        Log.pl("\ngameEngine is ready having this field: ${game.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(game.gameField))
+        assertEquals(7, getGameFieldSideLength(game.gameField))
     }
 
     @Test
     fun gameIsNotStarted_tooSmallGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength = 2 -> game would have no sense in this case, the same as with field size of 1
-        GameEngine.prepareGame(2, 2)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val game2x2 = GameEngine(2, 2)
+        Log.pl("\ngameEngine is ready having this field: ${game2x2.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(game2x2.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game2x2.gameField))
         // size = maxLength = 0
-        GameEngine.prepareGame(0, 0)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val game0x0 = GameEngine(0, 0)
+        Log.pl("\ngameEngine is ready having this field: ${game0x0.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(game0x0.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game0x0.gameField))
         // size = maxLength = -1
-        GameEngine.prepareGame(-1, -1)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameM1M1 = GameEngine(-1, -1)
+        Log.pl("\ngameEngine is ready having this field: ${gameM1M1.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameM1M1.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameM1M1.gameField))
         // size = maxLength = Int.MIN_VALUE
-        GameEngine.prepareGame(Int.MIN_VALUE, Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMxM = GameEngine(Int.MIN_VALUE, Int.MIN_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMxM.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMxM.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMxM.gameField))
     }
 
     @Test
     fun gameIsNotStarted_tooBigGameFieldIsCreated_maximal1000x1000GameFieldIsReady() {
         // size = maxLength = 1001 -> for now the limit is set to 1000 dots per side but in the future there could be more
-        GameEngine.prepareGame(1001, 1001)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val game1k1 = GameEngine(1001, 1001)
+        Log.pl("\ngameEngine is ready having this field: ${game1k1.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(game1k1.gameField))
+        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game1k1.gameField))
         // size = maxLength = Int.MAX_VALUE
-        GameEngine.prepareGame(Int.MAX_VALUE, Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMM = GameEngine(Int.MAX_VALUE, Int.MAX_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMM.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMM.gameField))
+        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMM.gameField))
     }
 
     @Suppress("INTEGER_OVERFLOW")
     @Test
     fun gameIsNotStarted_underMinIntGameFieldIsCreated_maximal1000x1000GameFieldIsReady() {
         // size = maxLength tries to be less than Int.MIN_VALUE -> there will be overflow of the Int
-        GameEngine.prepareGame(Int.MIN_VALUE - 1, Int.MIN_VALUE - 1)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val game = GameEngine(Int.MIN_VALUE - 1, Int.MIN_VALUE - 1)
+        Log.pl("\ngameEngine is ready having this field: ${game.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(game.gameField))
+        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
     }
 
     @Suppress("INTEGER_OVERFLOW")
     @Test
     fun gameIsNotStarted_overMaxIntGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength tries to be more than Int.MAX_VALUE -> there will be overflow of the Int
-        GameEngine.prepareGame(Int.MAX_VALUE + 1, Int.MAX_VALUE + 1)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val game = GameEngine(Int.MAX_VALUE + 1, Int.MAX_VALUE + 1)
+        Log.pl("\ngameEngine is ready having this field: ${game.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(game.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
     }
 
     // assertions of this test are made mostly to see interesting effects during different kinds of limits mixing
@@ -98,59 +93,59 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_MinAndMaxIntMixedGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength = Int.MIN_VALUE + Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
-        GameEngine.prepareGame(Int.MIN_VALUE + Int.MIN_VALUE, Int.MIN_VALUE + Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMinPlusMin = GameEngine(Int.MIN_VALUE + Int.MIN_VALUE, Int.MIN_VALUE + Int.MIN_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMin.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMinPlusMin.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMin.gameField))
         println(Int.MIN_VALUE + Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
-        GameEngine.prepareGame(Int.MIN_VALUE - Int.MIN_VALUE, Int.MIN_VALUE - Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMinMinusMin = GameEngine(Int.MIN_VALUE - Int.MIN_VALUE, Int.MIN_VALUE - Int.MIN_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMin.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMinMinusMin.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMin.gameField))
         println(Int.MIN_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MAX_VALUE = -2 in fact - this is an interesting effect of the Int
-        GameEngine.prepareGame(Int.MAX_VALUE + Int.MAX_VALUE, Int.MAX_VALUE + Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMaxPlusMax = GameEngine(Int.MAX_VALUE + Int.MAX_VALUE, Int.MAX_VALUE + Int.MAX_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMax.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMaxPlusMax.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMax.gameField))
         println(Int.MAX_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MAX_VALUE = 0 which is obvious
-        GameEngine.prepareGame(Int.MAX_VALUE - Int.MAX_VALUE, Int.MAX_VALUE - Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMaxMinusMax = GameEngine(Int.MAX_VALUE - Int.MAX_VALUE, Int.MAX_VALUE - Int.MAX_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMax.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMaxMinusMax.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMax.gameField))
         println(Int.MAX_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MAX_VALUE = +1 in fact - this is an interesting effect of the Int
-        GameEngine.prepareGame(Int.MIN_VALUE - Int.MAX_VALUE, Int.MIN_VALUE - Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMinMinusMax = GameEngine(Int.MIN_VALUE - Int.MAX_VALUE, Int.MIN_VALUE - Int.MAX_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMax.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMinMinusMax.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMax.gameField))
         println(Int.MIN_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MIN_VALUE = -1 which is obvious
-        GameEngine.prepareGame(Int.MAX_VALUE - Int.MIN_VALUE, Int.MAX_VALUE - Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMaxMinusMin = GameEngine(Int.MAX_VALUE - Int.MIN_VALUE, Int.MAX_VALUE - Int.MIN_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMin.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMaxMinusMin.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMin.gameField))
         println(Int.MAX_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE + Int.MAX_VALUE = -1 which is obvious
-        GameEngine.prepareGame(Int.MIN_VALUE + Int.MAX_VALUE, Int.MIN_VALUE + Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMinPlusMax = GameEngine(Int.MIN_VALUE + Int.MAX_VALUE, Int.MIN_VALUE + Int.MAX_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMax.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMinPlusMax.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMax.gameField))
         println(Int.MIN_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MIN_VALUE = -1 which is obvious
-        GameEngine.prepareGame(Int.MAX_VALUE + Int.MIN_VALUE, Int.MAX_VALUE + Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady())
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength())
+        val gameMaxPlusMin = GameEngine(Int.MAX_VALUE + Int.MIN_VALUE, Int.MAX_VALUE + Int.MIN_VALUE)
+        Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMin.gameField?.prepareForPrintingIn2d()}")
+        assertTrue(isGameFieldReady(gameMaxPlusMin.gameField))
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMin.gameField))
         println(Int.MAX_VALUE + Int.MIN_VALUE)
     }
 
@@ -193,31 +188,31 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_2AdjacentMarksAreSetByTheSamePlayer_detectedLineLengthIsCorrect() {
-        prepareClassic3x3GameField()
+        val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
-        GameEngine.makeMove(firstMark, Player.A)
-        GameEngine.makeMove(secondMark, Player.A)
-        GameEngine.printCurrentFieldIn2d()
+        game.makeMove(firstMark, Player.A)
+        game.makeMove(secondMark, Player.A)
+        game.printCurrentFieldIn2d()
         Log.pl("measuring line from $firstMark in the forward direction:")
-        val lengthFromFirstToSecond = GameEngine.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val lengthFromFirstToSecond = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
-        val lengthFromSecondToFirst = GameEngine.gameField?.measureLineFrom(secondMark, LineDirection.XmY0, 1)
+        val lengthFromSecondToFirst = game.gameField?.measureLineFrom(secondMark, LineDirection.XmY0, 1)
         assertEquals(2, lengthFromFirstToSecond)
         assertEquals(2, lengthFromSecondToFirst)
     }
 
     @Test
     fun having3x3Field_2RemoteMarksAreSetByTheSamePlayer_detectedLineLengthIsCorrect() {
-        prepareClassic3x3GameField()
+        val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
-        GameEngine.makeMove(firstMark, Player.A)
-        GameEngine.makeMove(secondMark, Player.A)
+        game.makeMove(firstMark, Player.A)
+        game.makeMove(secondMark, Player.A)
         Log.pl("measuring line from $firstMark in the forward direction:")
-        val lengthFromFirstToSecond = GameEngine.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val lengthFromFirstToSecond = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
-        val lengthFromSecondToFirst = GameEngine.gameField?.measureLineFrom(secondMark, LineDirection.XmY0, 1)
+        val lengthFromSecondToFirst = game.gameField?.measureLineFrom(secondMark, LineDirection.XmY0, 1)
         assertEquals(1, lengthFromFirstToSecond)
         assertEquals(1, lengthFromSecondToFirst)
         // 1 here is the given length of one dot on the field - if the mark exists - its min line length is 1, not less
@@ -225,17 +220,17 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_2RemoteMarksOfTheSamePlayerAreConnected_detectedLineLengthIsCorrect() {
-        prepareClassic3x3GameField()
+        val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
         val connectingMark = Coordinates(1, 0)
-        GameEngine.makeMove(firstMark, Player.A)
-        GameEngine.makeMove(secondMark, Player.A)
-        GameEngine.makeMove(connectingMark, Player.A)
+        game.makeMove(firstMark, Player.A)
+        game.makeMove(secondMark, Player.A)
+        game.makeMove(connectingMark, Player.A)
         Log.pl("measuring line from $firstMark in the forward direction:")
-        val lengthFromFirstToSecond = GameEngine.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val lengthFromFirstToSecond = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
-        val lengthFromSecondToFirst = GameEngine.gameField?.measureLineFrom(secondMark, LineDirection.XmY0, 1)
+        val lengthFromSecondToFirst = game.gameField?.measureLineFrom(secondMark, LineDirection.XmY0, 1)
         assertEquals(3, lengthFromFirstToSecond)
         assertEquals(3, lengthFromSecondToFirst)
         // 1 here is the given length of one dot on the field - if the mark exists - its min line length is 1, not less
@@ -243,17 +238,17 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_2AdjacentMarksOfTheSamePlayerAreAddedWithOneMoreMark_detectedLineLengthIsCorrect() {
-        prepareClassic3x3GameField()
+        val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
         val oneMoreMark = Coordinates(2, 0)
-        GameEngine.makeMove(firstMark, Player.A)
-        GameEngine.makeMove(secondMark, Player.A)
-        GameEngine.makeMove(oneMoreMark, Player.A)
+        game.makeMove(firstMark, Player.A)
+        game.makeMove(secondMark, Player.A)
+        game.makeMove(oneMoreMark, Player.A)
         Log.pl("measuring line from $firstMark in the forward direction:")
-        val lengthFromEdgeToEdge = GameEngine.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val lengthFromEdgeToEdge = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
-        val lengthFromEdgeToEdgeOpposite = GameEngine.gameField?.measureLineFrom(oneMoreMark, LineDirection.XmY0, 1)
+        val lengthFromEdgeToEdgeOpposite = game.gameField?.measureLineFrom(oneMoreMark, LineDirection.XmY0, 1)
         assertEquals(3, lengthFromEdgeToEdge)
         assertEquals(3, lengthFromEdgeToEdgeOpposite)
         // 1 here is the given length of one dot on the field - if the mark exists - its min line length is 1, not less
@@ -261,68 +256,77 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_2AdjacentMarksAreSetByDifferentPlayers_noLineIsCreatedForAnyPlayer() {
-        prepareClassic3x3GameField()
+        val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
-        val firstActivePlayer = GameEngine.activePlayer // should be player A
-        GameEngine.makeMove(firstMark) // after this line active player is replaced with the next -> B
+        val firstActivePlayer = game.activePlayer // should be player A
+        game.makeMove(firstMark) // after this line active player is replaced with the next -> B
         Log.pl("measuring line from $firstMark for player: $firstActivePlayer in the forward direction:")
-        val lengthForPlayerA = GameEngine.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
-        val secondActivePlayer = GameEngine.activePlayer // should be player B
-        GameEngine.makeMove(secondMark) // after this line active player is replaced with the next -> A
+        val lengthForPlayerA = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val secondActivePlayer = game.activePlayer // should be player B
+        game.makeMove(secondMark) // after this line active player is replaced with the next -> A
         Log.pl("measuring line from $secondMark for player: $secondActivePlayer in the forward direction:")
-        val lengthForPlayerB = GameEngine.gameField?.measureLineFrom(secondMark, LineDirection.XpY0, 1)
+        val lengthForPlayerB = game.gameField?.measureLineFrom(secondMark, LineDirection.XpY0, 1)
         assertEquals(1, lengthForPlayerA)
         assertEquals(1, lengthForPlayerB)
-        GameEngine.gameField?.prepareForPrintingIn2d()?.let { Log.pl(it) }
+        game.gameField?.prepareForPrintingIn2d()?.let { Log.pl(it) }
     }
 
     // endregion line length measurements
 
     @Test
     fun havingOneMarkSetForOnePlayerOn3x3Field_TryToSetMarkForAnotherPlayerInTheSamePlace_previousMarkRemainsUnchanged() {
-        prepareClassic3x3GameField()
+        val game = prepareClassic3x3GameField()
         val someSpot = Coordinates(1, 1)
-        GameEngine.makeMove(someSpot, Player.A)
-        GameEngine.makeMove(someSpot, Player.B)
-        Log.pl("\ngame field with only one player's mark: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertEquals(Player.A, GameEngine.gameField?.getCurrentMarkAt(1, 1))
+        game.makeMove(someSpot, Player.A)
+        game.makeMove(someSpot, Player.B)
+        Log.pl("\ngame field with only one player's mark: ${game.gameField?.prepareForPrintingIn2d()}")
+        assertEquals(Player.A, game.gameField?.getCurrentMarkAt(1, 1))
     }
 
     @Test
     fun having3x3Field_TryToSetMarkForThisPlayerOnWrongPosition_currentPlayerRemainsUnchanged() {
-        prepareClassic3x3GameField()
-        GameEngine.makeMove(-1, -1) // attempt to set the mark on a wrong place
-        assertEquals(Player.A, GameEngine.activePlayer) // this player remains chosen for the next move
-        GameEngine.makeMove(1, 1) // another attempt for the same player - this time successful
-        assertEquals(Player.B, GameEngine.activePlayer) // this time the next player is prepared for a move
-        Log.pl("\ngame field with only one player's mark: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        assertEquals(Player.A, GameEngine.gameField?.getCurrentMarkAt(1, 1))
+        val game = prepareClassic3x3GameField()
+        game.makeMove(-1, -1) // attempt to set the mark on a wrong place
+        assertEquals(Player.A, game.activePlayer) // this player remains chosen for the next move
+        game.makeMove(1, 1) // another attempt for the same player - this time successful
+        assertEquals(Player.B, game.activePlayer) // this time the next player is prepared for a move
+        Log.pl("\ngame field with only one player's mark: ${game.gameField?.prepareForPrintingIn2d()}")
+        assertEquals(Player.A, game.gameField?.getCurrentMarkAt(1, 1))
     }
 
     @Test
     fun having3x3Field_onlyOnePlayerMarksAreSet_victoryConditionIsCorrect() {
         println("having3x3Field_onlyOnePlayerMarksAreSet_victoryConditionIsCorrect")
-        prepareClassic3x3GameField()
-        GameEngine.makeMove(Coordinates(0, 0), Player.A)
-        GameEngine.makeMove(Coordinates(1, 0), Player.A)
-        GameEngine.makeMove(Coordinates(2, 0), Player.A)
+        val atttGame = AtttGame.create(3, 3)
+        val game = atttGame as GameEngine
+        game.makeMove(Coordinates(0, 0), Player.A)
+        game.makeMove(Coordinates(1, 0), Player.A)
+        println(game.getWinner().getMaxLineLength())
+        println(game.getLeader().getMaxLineLength())
+        game.makeMove(Coordinates(2, 0), Player.A)
         // gameField & winning message for player A is printed in the console
-        assertEquals(Player.A, GameEngine.getWinner())
-//        assertEquals(3, GameEngine.getWinner().getMaxLineLength()) // actual 5 when this test is launched in scope with others
+        assertEquals(Player.A, game.getWinner())
+        println("3x3 Player.A: ${game.getWinner().hashCode()}")
+        assertEquals(
+            3,
+            game.getWinner().getMaxLineLength()
+        ) // actual 5 when this test is launched in scope with others
+        // todo: fix
     }
 
     @Test
     fun having2LinesOfOnePlayerOn5x5Field_thisPlayerMarkIsSetInBetween_victoryConditionIsCorrect() {
-        GameEngine.prepareGame(5, 5)
-        Log.pl("\ntest5x5Field: gameEngine ready with given field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
-        GameEngine.makeMove(Coordinates(0, 0), Player.A)
-        GameEngine.makeMove(Coordinates(1, 0), Player.A)
-//    GameEngine.makeNewMove(Coordinates(2, 0), WhichPlayer.A) // intentionally commented - it will be used a bit later
-        GameEngine.makeMove(Coordinates(3, 0), Player.A)
-        GameEngine.makeMove(Coordinates(4, 0), Player.A)
-        GameEngine.makeMove(Coordinates(2, 0), Player.A) // intentionally placed here to connect 2 segments
-        assertEquals(Player.A, GameEngine.getWinner())
-        assertEquals(5, GameEngine.getWinner().getMaxLineLength())
+        val game = GameEngine(5, 5)
+        Log.pl("\ntest5x5Field: gameEngine ready with given field: ${game.gameField?.prepareForPrintingIn2d()}")
+        game.makeMove(Coordinates(0, 0), Player.A)
+        game.makeMove(Coordinates(1, 0), Player.A)
+        // GameEngine.makeNewMove(Coordinates(2, 0), WhichPlayer.A) // intentionally commented - it will be used a bit later
+        game.makeMove(Coordinates(3, 0), Player.A)
+        game.makeMove(Coordinates(4, 0), Player.A)
+        game.makeMove(Coordinates(2, 0), Player.A) // intentionally placed here to connect 2 segments
+        assertEquals(Player.A, game.getWinner())
+        println("5x5 Player.A: ${game.getWinner().hashCode()}")
+        assertEquals(5, game.getWinner().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -1,5 +1,5 @@
 import elements.*
-import logic.GameEngine
+import logic.GameSession
 import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.BeforeTest
@@ -24,7 +24,7 @@ class InternalElementsTesting {
 
     @Test
     fun gameIsNotStarted_gameFieldOfAnyCorrectSizeIsCreated_gameFieldWithSpecifiedSizeIsReady() {
-        val game = GameEngine(7, 5)
+        val game = GameSession(7, 5)
         Log.pl("\ngameEngine is ready having this field: ${game.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game.gameField))
         assertEquals(7, getGameFieldSideLength(game.gameField))
@@ -33,22 +33,22 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_tooSmallGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength = 2 -> game would have no sense in this case, the same as with field size of 1
-        val game2x2 = GameEngine(2, 2)
+        val game2x2 = GameSession(2, 2)
         Log.pl("\ngameEngine is ready having this field: ${game2x2.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game2x2.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game2x2.gameField))
         // size = maxLength = 0
-        val game0x0 = GameEngine(0, 0)
+        val game0x0 = GameSession(0, 0)
         Log.pl("\ngameEngine is ready having this field: ${game0x0.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game0x0.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game0x0.gameField))
         // size = maxLength = -1
-        val gameM1M1 = GameEngine(-1, -1)
+        val gameM1M1 = GameSession(-1, -1)
         Log.pl("\ngameEngine is ready having this field: ${gameM1M1.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameM1M1.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameM1M1.gameField))
         // size = maxLength = Int.MIN_VALUE
-        val gameMxM = GameEngine(Int.MIN_VALUE, Int.MIN_VALUE)
+        val gameMxM = GameSession(Int.MIN_VALUE, Int.MIN_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMxM.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMxM.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMxM.gameField))
@@ -57,12 +57,12 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_tooBigGameFieldIsCreated_maximal1000x1000GameFieldIsReady() {
         // size = maxLength = 1001 -> for now the limit is set to 1000 dots per side but in the future there could be more
-        val game1k1 = GameEngine(1001, 1001)
+        val game1k1 = GameSession(1001, 1001)
         Log.pl("\ngameEngine is ready having this field: ${game1k1.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game1k1.gameField))
         assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game1k1.gameField))
         // size = maxLength = Int.MAX_VALUE
-        val gameMM = GameEngine(Int.MAX_VALUE, Int.MAX_VALUE)
+        val gameMM = GameSession(Int.MAX_VALUE, Int.MAX_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMM.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMM.gameField))
         assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMM.gameField))
@@ -72,7 +72,7 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_underMinIntGameFieldIsCreated_maximal1000x1000GameFieldIsReady() {
         // size = maxLength tries to be less than Int.MIN_VALUE -> there will be overflow of the Int
-        val game = GameEngine(Int.MIN_VALUE - 1, Int.MIN_VALUE - 1)
+        val game = GameSession(Int.MIN_VALUE - 1, Int.MIN_VALUE - 1)
         Log.pl("\ngameEngine is ready having this field: ${game.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game.gameField))
         assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
@@ -82,7 +82,7 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_overMaxIntGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength tries to be more than Int.MAX_VALUE -> there will be overflow of the Int
-        val game = GameEngine(Int.MAX_VALUE + 1, Int.MAX_VALUE + 1)
+        val game = GameSession(Int.MAX_VALUE + 1, Int.MAX_VALUE + 1)
         Log.pl("\ngameEngine is ready having this field: ${game.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
@@ -93,56 +93,56 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_MinAndMaxIntMixedGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength = Int.MIN_VALUE + Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
-        val gameMinPlusMin = GameEngine(Int.MIN_VALUE + Int.MIN_VALUE, Int.MIN_VALUE + Int.MIN_VALUE)
+        val gameMinPlusMin = GameSession(Int.MIN_VALUE + Int.MIN_VALUE, Int.MIN_VALUE + Int.MIN_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMin.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinPlusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMin.gameField))
         println(Int.MIN_VALUE + Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
-        val gameMinMinusMin = GameEngine(Int.MIN_VALUE - Int.MIN_VALUE, Int.MIN_VALUE - Int.MIN_VALUE)
+        val gameMinMinusMin = GameSession(Int.MIN_VALUE - Int.MIN_VALUE, Int.MIN_VALUE - Int.MIN_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMin.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinMinusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMin.gameField))
         println(Int.MIN_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MAX_VALUE = -2 in fact - this is an interesting effect of the Int
-        val gameMaxPlusMax = GameEngine(Int.MAX_VALUE + Int.MAX_VALUE, Int.MAX_VALUE + Int.MAX_VALUE)
+        val gameMaxPlusMax = GameSession(Int.MAX_VALUE + Int.MAX_VALUE, Int.MAX_VALUE + Int.MAX_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMax.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxPlusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMax.gameField))
         println(Int.MAX_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MAX_VALUE = 0 which is obvious
-        val gameMaxMinusMax = GameEngine(Int.MAX_VALUE - Int.MAX_VALUE, Int.MAX_VALUE - Int.MAX_VALUE)
+        val gameMaxMinusMax = GameSession(Int.MAX_VALUE - Int.MAX_VALUE, Int.MAX_VALUE - Int.MAX_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMax.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxMinusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMax.gameField))
         println(Int.MAX_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MAX_VALUE = +1 in fact - this is an interesting effect of the Int
-        val gameMinMinusMax = GameEngine(Int.MIN_VALUE - Int.MAX_VALUE, Int.MIN_VALUE - Int.MAX_VALUE)
+        val gameMinMinusMax = GameSession(Int.MIN_VALUE - Int.MAX_VALUE, Int.MIN_VALUE - Int.MAX_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMax.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinMinusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMax.gameField))
         println(Int.MIN_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MIN_VALUE = -1 which is obvious
-        val gameMaxMinusMin = GameEngine(Int.MAX_VALUE - Int.MIN_VALUE, Int.MAX_VALUE - Int.MIN_VALUE)
+        val gameMaxMinusMin = GameSession(Int.MAX_VALUE - Int.MIN_VALUE, Int.MAX_VALUE - Int.MIN_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMin.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxMinusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMin.gameField))
         println(Int.MAX_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE + Int.MAX_VALUE = -1 which is obvious
-        val gameMinPlusMax = GameEngine(Int.MIN_VALUE + Int.MAX_VALUE, Int.MIN_VALUE + Int.MAX_VALUE)
+        val gameMinPlusMax = GameSession(Int.MIN_VALUE + Int.MAX_VALUE, Int.MIN_VALUE + Int.MAX_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMax.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinPlusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMax.gameField))
         println(Int.MIN_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MIN_VALUE = -1 which is obvious
-        val gameMaxPlusMin = GameEngine(Int.MAX_VALUE + Int.MIN_VALUE, Int.MAX_VALUE + Int.MIN_VALUE)
+        val gameMaxPlusMin = GameSession(Int.MAX_VALUE + Int.MIN_VALUE, Int.MAX_VALUE + Int.MIN_VALUE)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMin.gameField?.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxPlusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMin.gameField))
@@ -299,7 +299,7 @@ class InternalElementsTesting {
     fun having3x3Field_onlyOnePlayerMarksAreSet_victoryConditionIsCorrect() {
         println("having3x3Field_onlyOnePlayerMarksAreSet_victoryConditionIsCorrect")
         val atttGame = AtttGame.create(3, 3)
-        val game = atttGame as GameEngine
+        val game = atttGame as GameSession
         game.makeMove(Coordinates(0, 0), Player.A)
         game.makeMove(Coordinates(1, 0), Player.A)
         println(game.getWinner().getMaxLineLength())
@@ -317,7 +317,7 @@ class InternalElementsTesting {
 
     @Test
     fun having2LinesOfOnePlayerOn5x5Field_thisPlayerMarkIsSetInBetween_victoryConditionIsCorrect() {
-        val game = GameEngine(5, 5)
+        val game = GameSession(5, 5)
         Log.pl("\ntest5x5Field: gameEngine ready with given field: ${game.gameField?.prepareForPrintingIn2d()}")
         game.makeMove(Coordinates(0, 0), Player.A)
         game.makeMove(Coordinates(1, 0), Player.A)

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -25,7 +25,7 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_gameFieldOfAnyCorrectSizeIsCreated_gameFieldWithSpecifiedSizeIsReady() {
         val game = GameSession(7, 5)
-        Log.pl("\ngameEngine is ready having this field: ${game.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${game.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game.gameField))
         assertEquals(7, getGameFieldSideLength(game.gameField))
     }
@@ -34,22 +34,22 @@ class InternalElementsTesting {
     fun gameIsNotStarted_tooSmallGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength = 2 -> game would have no sense in this case, the same as with field size of 1
         val game2x2 = GameSession(2, 2)
-        Log.pl("\ngameEngine is ready having this field: ${game2x2.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${game2x2.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game2x2.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game2x2.gameField))
         // size = maxLength = 0
         val game0x0 = GameSession(0, 0)
-        Log.pl("\ngameEngine is ready having this field: ${game0x0.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${game0x0.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game0x0.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game0x0.gameField))
         // size = maxLength = -1
         val gameM1M1 = GameSession(-1, -1)
-        Log.pl("\ngameEngine is ready having this field: ${gameM1M1.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameM1M1.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameM1M1.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameM1M1.gameField))
         // size = maxLength = Int.MIN_VALUE
         val gameMxM = GameSession(Int.MIN_VALUE, Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMxM.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMxM.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMxM.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMxM.gameField))
     }
@@ -58,12 +58,12 @@ class InternalElementsTesting {
     fun gameIsNotStarted_tooBigGameFieldIsCreated_maximal1000x1000GameFieldIsReady() {
         // size = maxLength = 1001 -> for now the limit is set to 1000 dots per side but in the future there could be more
         val game1k1 = GameSession(1001, 1001)
-        Log.pl("\ngameEngine is ready having this field: ${game1k1.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${game1k1.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game1k1.gameField))
         assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game1k1.gameField))
         // size = maxLength = Int.MAX_VALUE
         val gameMM = GameSession(Int.MAX_VALUE, Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMM.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMM.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMM.gameField))
         assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMM.gameField))
     }
@@ -73,7 +73,7 @@ class InternalElementsTesting {
     fun gameIsNotStarted_underMinIntGameFieldIsCreated_maximal1000x1000GameFieldIsReady() {
         // size = maxLength tries to be less than Int.MIN_VALUE -> there will be overflow of the Int
         val game = GameSession(Int.MIN_VALUE - 1, Int.MIN_VALUE - 1)
-        Log.pl("\ngameEngine is ready having this field: ${game.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${game.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game.gameField))
         assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
     }
@@ -83,7 +83,7 @@ class InternalElementsTesting {
     fun gameIsNotStarted_overMaxIntGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength tries to be more than Int.MAX_VALUE -> there will be overflow of the Int
         val game = GameSession(Int.MAX_VALUE + 1, Int.MAX_VALUE + 1)
-        Log.pl("\ngameEngine is ready having this field: ${game.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${game.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
     }
@@ -94,56 +94,56 @@ class InternalElementsTesting {
     fun gameIsNotStarted_MinAndMaxIntMixedGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength = Int.MIN_VALUE + Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
         val gameMinPlusMin = GameSession(Int.MIN_VALUE + Int.MIN_VALUE, Int.MIN_VALUE + Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMin.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMin.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinPlusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMin.gameField))
         println(Int.MIN_VALUE + Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
         val gameMinMinusMin = GameSession(Int.MIN_VALUE - Int.MIN_VALUE, Int.MIN_VALUE - Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMin.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMin.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinMinusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMin.gameField))
         println(Int.MIN_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MAX_VALUE = -2 in fact - this is an interesting effect of the Int
         val gameMaxPlusMax = GameSession(Int.MAX_VALUE + Int.MAX_VALUE, Int.MAX_VALUE + Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMax.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMax.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxPlusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMax.gameField))
         println(Int.MAX_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MAX_VALUE = 0 which is obvious
         val gameMaxMinusMax = GameSession(Int.MAX_VALUE - Int.MAX_VALUE, Int.MAX_VALUE - Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMax.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMax.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxMinusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMax.gameField))
         println(Int.MAX_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MAX_VALUE = +1 in fact - this is an interesting effect of the Int
         val gameMinMinusMax = GameSession(Int.MIN_VALUE - Int.MAX_VALUE, Int.MIN_VALUE - Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMax.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMax.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinMinusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMax.gameField))
         println(Int.MIN_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MIN_VALUE = -1 which is obvious
         val gameMaxMinusMin = GameSession(Int.MAX_VALUE - Int.MIN_VALUE, Int.MAX_VALUE - Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMin.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMin.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxMinusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMin.gameField))
         println(Int.MAX_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE + Int.MAX_VALUE = -1 which is obvious
         val gameMinPlusMax = GameSession(Int.MIN_VALUE + Int.MAX_VALUE, Int.MIN_VALUE + Int.MAX_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMax.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMax.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinPlusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMax.gameField))
         println(Int.MIN_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MIN_VALUE = -1 which is obvious
         val gameMaxPlusMin = GameSession(Int.MAX_VALUE + Int.MIN_VALUE, Int.MAX_VALUE + Int.MIN_VALUE)
-        Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMin.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMin.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxPlusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMin.gameField))
         println(Int.MAX_VALUE + Int.MIN_VALUE)
@@ -195,9 +195,9 @@ class InternalElementsTesting {
         game.makeMove(secondMark, Player.A)
         game.printCurrentFieldIn2d()
         Log.pl("measuring line from $firstMark in the forward direction:")
-        val lengthFromFirstToSecond = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
-        val lengthFromSecondToFirst = game.gameField?.measureLineFrom(secondMark, LineDirection.XmY0, 1)
+        val lengthFromSecondToFirst = game.gameField.measureLineFrom(secondMark, LineDirection.XmY0, 1)
         assertEquals(2, lengthFromFirstToSecond)
         assertEquals(2, lengthFromSecondToFirst)
     }
@@ -210,9 +210,9 @@ class InternalElementsTesting {
         game.makeMove(firstMark, Player.A)
         game.makeMove(secondMark, Player.A)
         Log.pl("measuring line from $firstMark in the forward direction:")
-        val lengthFromFirstToSecond = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
-        val lengthFromSecondToFirst = game.gameField?.measureLineFrom(secondMark, LineDirection.XmY0, 1)
+        val lengthFromSecondToFirst = game.gameField.measureLineFrom(secondMark, LineDirection.XmY0, 1)
         assertEquals(1, lengthFromFirstToSecond)
         assertEquals(1, lengthFromSecondToFirst)
         // 1 here is the given length of one dot on the field - if the mark exists - its min line length is 1, not less
@@ -228,9 +228,9 @@ class InternalElementsTesting {
         game.makeMove(secondMark, Player.A)
         game.makeMove(connectingMark, Player.A)
         Log.pl("measuring line from $firstMark in the forward direction:")
-        val lengthFromFirstToSecond = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
-        val lengthFromSecondToFirst = game.gameField?.measureLineFrom(secondMark, LineDirection.XmY0, 1)
+        val lengthFromSecondToFirst = game.gameField.measureLineFrom(secondMark, LineDirection.XmY0, 1)
         assertEquals(3, lengthFromFirstToSecond)
         assertEquals(3, lengthFromSecondToFirst)
         // 1 here is the given length of one dot on the field - if the mark exists - its min line length is 1, not less
@@ -246,9 +246,9 @@ class InternalElementsTesting {
         game.makeMove(secondMark, Player.A)
         game.makeMove(oneMoreMark, Player.A)
         Log.pl("measuring line from $firstMark in the forward direction:")
-        val lengthFromEdgeToEdge = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val lengthFromEdgeToEdge = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
-        val lengthFromEdgeToEdgeOpposite = game.gameField?.measureLineFrom(oneMoreMark, LineDirection.XmY0, 1)
+        val lengthFromEdgeToEdgeOpposite = game.gameField.measureLineFrom(oneMoreMark, LineDirection.XmY0, 1)
         assertEquals(3, lengthFromEdgeToEdge)
         assertEquals(3, lengthFromEdgeToEdgeOpposite)
         // 1 here is the given length of one dot on the field - if the mark exists - its min line length is 1, not less
@@ -262,14 +262,14 @@ class InternalElementsTesting {
         val firstActivePlayer = game.activePlayer // should be player A
         game.makeMove(firstMark) // after this line active player is replaced with the next -> B
         Log.pl("measuring line from $firstMark for player: $firstActivePlayer in the forward direction:")
-        val lengthForPlayerA = game.gameField?.measureLineFrom(firstMark, LineDirection.XpY0, 1)
+        val lengthForPlayerA = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         val secondActivePlayer = game.activePlayer // should be player B
         game.makeMove(secondMark) // after this line active player is replaced with the next -> A
         Log.pl("measuring line from $secondMark for player: $secondActivePlayer in the forward direction:")
-        val lengthForPlayerB = game.gameField?.measureLineFrom(secondMark, LineDirection.XpY0, 1)
+        val lengthForPlayerB = game.gameField.measureLineFrom(secondMark, LineDirection.XpY0, 1)
         assertEquals(1, lengthForPlayerA)
         assertEquals(1, lengthForPlayerB)
-        game.gameField?.prepareForPrintingIn2d()?.let { Log.pl(it) }
+        Log.pl(game.gameField.prepareForPrintingIn2d())
     }
 
     // endregion line length measurements
@@ -280,8 +280,8 @@ class InternalElementsTesting {
         val someSpot = Coordinates(1, 1)
         game.makeMove(someSpot, Player.A)
         game.makeMove(someSpot, Player.B)
-        Log.pl("\ngame field with only one player's mark: ${game.gameField?.prepareForPrintingIn2d()}")
-        assertEquals(Player.A, game.gameField?.getCurrentMarkAt(1, 1))
+        Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
+        assertEquals(Player.A, game.gameField.getCurrentMarkAt(1, 1))
     }
 
     @Test
@@ -291,8 +291,8 @@ class InternalElementsTesting {
         assertEquals(Player.A, game.activePlayer) // this player remains chosen for the next move
         game.makeMove(1, 1) // another attempt for the same player - this time successful
         assertEquals(Player.B, game.activePlayer) // this time the next player is prepared for a move
-        Log.pl("\ngame field with only one player's mark: ${game.gameField?.prepareForPrintingIn2d()}")
-        assertEquals(Player.A, game.gameField?.getCurrentMarkAt(1, 1))
+        Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
+        assertEquals(Player.A, game.gameField.getCurrentMarkAt(1, 1))
     }
 
     @Test
@@ -318,7 +318,7 @@ class InternalElementsTesting {
     @Test
     fun having2LinesOfOnePlayerOn5x5Field_thisPlayerMarkIsSetInBetween_victoryConditionIsCorrect() {
         val game = GameSession(5, 5)
-        Log.pl("\ntest5x5Field: gameEngine ready with given field: ${game.gameField?.prepareForPrintingIn2d()}")
+        Log.pl("\ntest5x5Field: gameEngine ready with given field: ${game.gameField.prepareForPrintingIn2d()}")
         game.makeMove(Coordinates(0, 0), Player.A)
         game.makeMove(Coordinates(1, 0), Player.A)
         // GameEngine.makeNewMove(Coordinates(2, 0), WhichPlayer.A) // intentionally commented - it will be used a bit later

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
@@ -1,5 +1,4 @@
 import elements.Player
-import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -43,7 +42,7 @@ class PublicApiTesting {
         game.mm(1, 0) // B
         game.mm(0, 1) // A -> now A has a line of 2 marks
         assertEquals(Player.A, game.getLeader())
-//        assertEquals(2, game.getLeader().getMaxLineLength())
+        assertEquals(2, game.getLeader().getMaxLineLength())
     }
 
     @Test

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
@@ -25,7 +25,7 @@ internal fun checkTheNextSpotDetectionBlock(startSpot: Coordinates) {
 internal fun checkTheNextSpotDetectionForLineDirection(startSpot: Coordinates, direction: LineDirection) {
     // as gameField is a stateful object - we have to reset it every time before a new test
     val game = prepareClassic3x3GameField()
-    val nextSpot = game.gameField?.getTheNextSafeSpaceFor(startSpot, direction)
+    val nextSpot = game.gameField.getTheNextSafeSpaceFor(startSpot, direction)
     Log.pl("nextSpot on 3x3 field for $direction is $nextSpot")
     when {
         // lowest limit for X axis
@@ -52,7 +52,7 @@ internal fun checkTheNextSpotDetectionForLineDirection(startSpot: Coordinates, d
 internal fun prepareClassic3x3GameField(): GameSession {
     // using internal API here instead of AtttGame as this function is used inside group of tests in InternalApiTesting
     val game3x3 = GameSession(3, 3)
-    Log.pl("\nprepareClassic3x3GameField: gameEngine is ready having this field: ${game3x3.gameField?.prepareForPrintingIn2d()}")
+    Log.pl("\nprepareClassic3x3GameField: gameEngine is ready having this field: ${game3x3.gameField.prepareForPrintingIn2d()}")
     return game3x3
 }
 

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
@@ -1,7 +1,7 @@
 import elements.Border
 import elements.Coordinates
 import elements.LineDirection
-import logic.GameEngine
+import logic.GameSession
 import logic.GameField
 import publicApi.AtttGame
 import utilities.Log
@@ -49,9 +49,9 @@ internal fun checkTheNextSpotDetectionForLineDirection(startSpot: Coordinates, d
     }
 }
 
-internal fun prepareClassic3x3GameField(): GameEngine {
+internal fun prepareClassic3x3GameField(): GameSession {
     // using internal API here instead of AtttGame as this function is used inside group of tests in InternalApiTesting
-    val game3x3 = GameEngine(3, 3)
+    val game3x3 = GameSession(3, 3)
     Log.pl("\nprepareClassic3x3GameField: gameEngine is ready having this field: ${game3x3.gameField?.prepareForPrintingIn2d()}")
     return game3x3
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
@@ -2,6 +2,7 @@ import elements.Border
 import elements.Coordinates
 import elements.LineDirection
 import logic.GameEngine
+import logic.GameField
 import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.assertEquals
@@ -23,8 +24,8 @@ internal fun checkTheNextSpotDetectionBlock(startSpot: Coordinates) {
 
 internal fun checkTheNextSpotDetectionForLineDirection(startSpot: Coordinates, direction: LineDirection) {
     // as gameField is a stateful object - we have to reset it every time before a new test
-    prepareClassic3x3GameField()
-    val nextSpot = GameEngine.gameField?.getTheNextSafeSpaceFor(startSpot, direction)
+    val game = prepareClassic3x3GameField()
+    val nextSpot = game.gameField?.getTheNextSafeSpaceFor(startSpot, direction)
     Log.pl("nextSpot on 3x3 field for $direction is $nextSpot")
     when {
         // lowest limit for X axis
@@ -48,21 +49,21 @@ internal fun checkTheNextSpotDetectionForLineDirection(startSpot: Coordinates, d
     }
 }
 
-internal fun prepareClassic3x3GameField() {
+internal fun prepareClassic3x3GameField(): GameEngine {
     // using internal API here instead of AtttGame as this function is used inside group of tests in InternalApiTesting
-    GameEngine.prepareGame(3, 3)
-    Log.pl("\nprepareClassic3x3GameField: gameEngine is ready having this field: ${GameEngine.gameField?.prepareForPrintingIn2d()}")
+    val game3x3 = GameEngine(3, 3)
+    Log.pl("\nprepareClassic3x3GameField: gameEngine is ready having this field: ${game3x3.gameField?.prepareForPrintingIn2d()}")
+    return game3x3
 }
 
 // should use only publicly available API
 internal fun prepareGameInstanceForClassic3x3GameField(): AtttGame {
-    val gameInstance = AtttGame.create()
-    gameInstance.prepareGame(3, 3)
+    val gameInstance = AtttGame.create(3, 3)
     Log.pl("\nprepareGameInstanceForClassic3x3GameField: gameInstance is ready having this field:")
     gameInstance.printCurrentFieldIn2d()
     return gameInstance
 }
 
-internal fun isGameFieldReady() = GameEngine.gameField?.isReady() == true
+internal fun isGameFieldReady(gameField: GameField?) = gameField?.isReady() == true
 
-internal fun getGameFieldSideLength() = GameEngine.gameField?.sideLength ?: -1
+internal fun getGameFieldSideLength(gameField: GameField?) = gameField?.sideLength ?: -1


### PR DESCRIPTION
I decided to avoid the nullability of GameField & GameRules instances inside GameEngine, and by the way to get rid of all clear() & finish() invocations. from now on all played instances of GameSession are meant to be removed by the Garbage Collector only.