### PR TITLE
Fix maxLineLength in Player for tests

### DIFF
--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
@@ -2,20 +2,21 @@ package elements
 
 import publicApi.AtttPlayer
 
-internal const val SYMBOL_FOR_ABSENT_MARK = '.'
-internal const val SYMBOL_FOR_PLAYER_A = 'X'
-internal const val SYMBOL_FOR_PLAYER_B = 'O'
 // todo: later make the symbol configurable - because we can have more than 2 players in perspective
 
 // for now, 2 players is enough, but in the future we will have more
-enum class Player(private val symbol: Char) : AtttPlayer {
-
+internal class Player(
+    private val id: Int, private val name: String? = null, private val symbol: Char
+) : AtttPlayer {
     // player None was added to avoid nullability in all places that require use of this class
-    None(SYMBOL_FOR_ABSENT_MARK), A(SYMBOL_FOR_PLAYER_A), B(SYMBOL_FOR_PLAYER_B);
 
-    private var maxLineLength = 0
+    private var maxLineLength = 0 // not using get & set here as this data is accessed from AtttPlayer interface
 
-    override fun getSymbol(): Char = this.symbol
+    override fun getId(): Int = id
+
+    override fun getName(): String? = name
+
+    override fun getSymbol(): Char = symbol
 
     override fun getMaxLineLength(): Int = maxLineLength
 

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
@@ -2,21 +2,17 @@ package elements
 
 import publicApi.AtttPlayer
 
-// todo: later make the symbol configurable - because we can have more than 2 players in perspective
-
-// for now, 2 players is enough, but in the future we will have more
 internal class Player(
-    private val id: Int, private val name: String? = null, private val symbol: Char
+    private val id: Int, private val name: String? = null, private val symbol: Char? = null
 ) : AtttPlayer {
-    // player None was added to avoid nullability in all places that require use of this class
 
     private var maxLineLength = 0 // not using get & set here as this data is accessed from AtttPlayer interface
 
-    override fun getId(): Int = id
+    override fun getId(): Int = id // this is the main criterion to distinguish one player from any other
 
-    override fun getName(): String? = name
+    override fun getName(): String? = name // optional as the name is not required to play the game
 
-    override fun getSymbol(): Char = symbol
+    override fun getSymbol(): Char? = symbol // this works mostly for a 2d field
 
     override fun getMaxLineLength(): Int = maxLineLength
 

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameField.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameField.kt
@@ -55,7 +55,7 @@ internal class GameField(
         sideLength in MIN_GAME_FIELD_SIDE_SIZE..MAX_GAME_FIELD_SIDE_SIZE && theMap.isEmpty()
 
     internal fun placeNewMark(where: Coordinates, what: AtttPlayer): Boolean =
-        if (theMap[where] == Player.None || theMap[where] == null) {
+        if (theMap[where] == PlayerProvider.None || theMap[where] == null) {
             theMap[where] = what
             true // new mark is successfully placed
         } else {

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameRules.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameRules.kt
@@ -2,7 +2,6 @@ package logic
 
 import elements.MAX_WINNING_LINE_LENGTH
 import elements.MIN_WINNING_LINE_LENGTH
-import elements.Player
 import publicApi.AtttPlayer
 
 /**
@@ -26,7 +25,7 @@ internal class GameRules(
 
     internal fun getWinner(): AtttPlayer? = theWinner
 
-    internal fun getLeadingPlayer(): AtttPlayer = detectLeadingPlayer() ?: Player.None
+    internal fun getLeadingPlayer(): AtttPlayer = detectLeadingPlayer() ?: PlayerProvider.None
 
     // here we need the player - not its line length, so do not use maxOfOrNull {...} as it returns Int? in this case
     private fun detectLeadingPlayer(): AtttPlayer? = maxLines.entries.maxByOrNull { k -> k.value }?.key

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -20,6 +20,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
     internal var activePlayer: AtttPlayer = PlayerProvider.None
 
     init {
+        PlayerProvider.prepareNewPlayersInstances()
         prepareNextPlayer() // this invocation sets the activePlayer to the first Player among others
     }
 

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -16,12 +16,9 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
     internal var gameField: GameField = GameField(desiredFieldSize)
     private var gameRules: GameRules = GameRules(desiredMaxLineLength)
 
-    // this is a part of inner game logic - it should be used only internally, for now there's no need to show it to a client
-    internal var activePlayer: AtttPlayer = PlayerProvider.None
-
     init {
         PlayerProvider.prepareNewPlayersInstances()
-        prepareNextPlayer() // this invocation sets the activePlayer to the first Player among others
+        PlayerProvider.presetNextPlayer() // this invocation sets the activePlayer to the first Player among others
     }
 
     // -------
@@ -39,13 +36,13 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
     override fun makeMove(x: Int, y: Int): AtttPlayer = if (gameField.isCorrectPosition(x, y)) {
         makeMove(Coordinates(x, y))
     } else {
-        activePlayer
+        PlayerProvider.activePlayer
     }
 
     /**
      * this function is actually the only place for making moves and thus changing the game field
      */
-    internal fun makeMove(where: Coordinates, what: AtttPlayer = activePlayer): AtttPlayer =
+    internal fun makeMove(where: Coordinates, what: AtttPlayer = PlayerProvider.activePlayer): AtttPlayer =
         if (gameField.placeNewMark(where, what)) {
             // analyze this new dot & detect if it creates or changes any lines in all possible directions
             val existingLineDirections = gameField.detectAllExistingLineDirectionsFromThePlacedMark(where)
@@ -57,7 +54,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
                 (what as Player).tryToSetMaxLineLength(it) // this cast is secure as Player is direct inheritor to AtttPlayer
                 updateGameScore(what, it)
             }
-            prepareNextPlayer()
+            PlayerProvider.presetNextPlayer()
         } else {
             what
         }
@@ -87,16 +84,6 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
     // endregion PUBLIC API
     // --------
     // region ALL PRIVATE
-
-    /**
-     * sets the currently active player, for which a move will be made & returns the player for the next move
-     */
-    private fun prepareNextPlayer(): AtttPlayer {
-        activePlayer =
-            if (activePlayer == PlayerProvider.X) PlayerProvider.O
-            else PlayerProvider.X // A is set after None & null case as well
-        return activePlayer
-    }
 
     /**
      * gameRules data is updated only here

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -17,7 +17,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
     private var gameRules: GameRules = GameRules(desiredMaxLineLength)
 
     // this is a part of inner game logic - it should be used only internally, for now there's no need to show it to a client
-    internal var activePlayer: AtttPlayer = Player.None
+    internal var activePlayer: AtttPlayer = PlayerProvider.None
 
     init {
         prepareNextPlayer() // this invocation sets the activePlayer to the first Player among others
@@ -69,7 +69,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
     /**
      * there can be only one winner - Player.None is returned until the winner not yet detected
      */
-    override fun getWinner(): AtttPlayer = gameRules.getWinner() ?: Player.None
+    override fun getWinner(): AtttPlayer = gameRules.getWinner() ?: PlayerProvider.None
 
     /**
      * after the winner is detected there is no way to modify the game field, so the game state is preserved
@@ -91,7 +91,9 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
      * sets the currently active player, for which a move will be made & returns the player for the next move
      */
     private fun prepareNextPlayer(): AtttPlayer {
-        activePlayer = if (activePlayer == Player.A) Player.B else Player.A // A is set after None & null case as well
+        activePlayer =
+            if (activePlayer == PlayerProvider.A) PlayerProvider.B
+            else PlayerProvider.A // A is set after None & null case as well
         return activePlayer
     }
 

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -18,7 +18,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
 
     init {
         PlayerProvider.prepareNewPlayersInstances()
-        PlayerProvider.presetNextPlayer() // this invocation sets the activePlayer to the first Player among others
+        PlayerProvider.presetNextPlayer() // this invocation sets the activePlayer to the starting Player among others
     }
 
     // -------

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -93,8 +93,8 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
      */
     private fun prepareNextPlayer(): AtttPlayer {
         activePlayer =
-            if (activePlayer == PlayerProvider.A) PlayerProvider.B
-            else PlayerProvider.A // A is set after None & null case as well
+            if (activePlayer == PlayerProvider.X) PlayerProvider.O
+            else PlayerProvider.X // A is set after None & null case as well
         return activePlayer
     }
 

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
@@ -1,0 +1,38 @@
+package logic
+
+import elements.Player
+import publicApi.AtttPlayer
+
+internal const val SYMBOL_FOR_ABSENT_MARK = '.'
+
+// for now - just the replacement of the former enums use
+internal object PlayerProvider {
+    /*
+        private var idCounter = -1
+        val nextAvailableId: Int
+            get() = idCounter++
+    */
+    val idForPlayerA = 0
+    val idForPlayerB = 1
+    val idForPlayerNone = -1
+
+    val symbolForPlayerA = 'X'
+    val symbolForPlayerB = 'O'
+    val symbolForPlayerNone = 'n'
+
+    // this is a very temporary solution to just check the failing tests -> then the architecture will get better
+    val A: AtttPlayer = Player(idForPlayerA, "PlayerA", symbolForPlayerA)
+//        private set
+    var B: AtttPlayer = Player(idForPlayerB, "PlayerB", symbolForPlayerB)
+//        private set
+    val None: AtttPlayer = Player(idForPlayerNone, "PlayerNone", symbolForPlayerNone) // one for all cases
+
+    init {
+        prepareNewPlayersInstances()
+    }
+
+    private fun prepareNewPlayersInstances() {
+//        A = Player(idForPlayerA, "PlayerA", symbolForPlayerA)
+//        B = Player(idForPlayerB, "PlayerB", symbolForPlayerB)
+    }
+}

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
@@ -23,10 +23,22 @@ internal object PlayerProvider {
         private set
     val None: AtttPlayer = Player(idForPlayerNone, "PlayerNone", symbolForPlayerNone) // one for all cases
 
+    // this is a part of inner game logic - it should be used only internally, for now there's no need to show it to a client
+    internal var activePlayer: AtttPlayer = None
+        private set
+
     // creates new instances for all players for every new GameSession instance
     internal fun prepareNewPlayersInstances() {
         X = createNewPlayerX()
         O = createNewPlayerO()
+    }
+
+    /**
+     * sets the currently active player, for which a move will be made & returns the player for the next move
+     */
+    internal fun presetNextPlayer(): AtttPlayer {
+        activePlayer = if (activePlayer == X) O else X // A is set after None & null case as well
+        return activePlayer
     }
 
     private fun createNewPlayerX() = Player(idForPlayerX, "PlayerX", symbolForPlayerX)

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
@@ -5,6 +5,14 @@ import publicApi.AtttPlayer
 
 internal const val SYMBOL_FOR_ABSENT_MARK = '.'
 
+private const val idForPlayerA = 0
+private const val idForPlayerB = 1
+private const val idForPlayerNone = -1
+
+private const val symbolForPlayerA = 'X'
+private const val symbolForPlayerB = 'O'
+private const val symbolForPlayerNone = 'n'
+
 // for now - just the replacement of the former enums use
 internal object PlayerProvider {
     /*
@@ -12,27 +20,17 @@ internal object PlayerProvider {
         val nextAvailableId: Int
             get() = idCounter++
     */
-    val idForPlayerA = 0
-    val idForPlayerB = 1
-    val idForPlayerNone = -1
-
-    val symbolForPlayerA = 'X'
-    val symbolForPlayerB = 'O'
-    val symbolForPlayerNone = 'n'
 
     // this is a very temporary solution to just check the failing tests -> then the architecture will get better
-    val A: AtttPlayer = Player(idForPlayerA, "PlayerA", symbolForPlayerA)
-//        private set
+    var A: AtttPlayer = Player(idForPlayerA, "PlayerA", symbolForPlayerA)
+        private set
     var B: AtttPlayer = Player(idForPlayerB, "PlayerB", symbolForPlayerB)
-//        private set
+        private set
     val None: AtttPlayer = Player(idForPlayerNone, "PlayerNone", symbolForPlayerNone) // one for all cases
 
-    init {
-        prepareNewPlayersInstances()
-    }
-
-    private fun prepareNewPlayersInstances() {
-//        A = Player(idForPlayerA, "PlayerA", symbolForPlayerA)
-//        B = Player(idForPlayerB, "PlayerB", symbolForPlayerB)
+    // creates new instances for all players for every new GameSession instance
+    internal fun prepareNewPlayersInstances() {
+        A = Player(idForPlayerA, "PlayerA", symbolForPlayerA)
+        B = Player(idForPlayerB, "PlayerB", symbolForPlayerB)
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
@@ -3,14 +3,14 @@ package logic
 import elements.Player
 import publicApi.AtttPlayer
 
-internal const val SYMBOL_FOR_ABSENT_MARK = '.'
+internal const val SYMBOL_FOR_ABSENT_MARK = '·'
 
-private const val idForPlayerA = 0
-private const val idForPlayerB = 1
+private const val idForPlayerX = 42 // of course, you know why exactly 42 :)
+private const val idForPlayerO = 0
 private const val idForPlayerNone = -1
 
-private const val symbolForPlayerA = 'X'
-private const val symbolForPlayerB = 'O'
+private const val symbolForPlayerX = 'X'
+private const val symbolForPlayerO = 'O'
 private const val symbolForPlayerNone = 'n'
 
 // for now - just the replacement of the former enums use
@@ -22,15 +22,15 @@ internal object PlayerProvider {
     */
 
     // this is a very temporary solution to just check the failing tests -> then the architecture will get better
-    var A: AtttPlayer = Player(idForPlayerA, "PlayerA", symbolForPlayerA)
+    var X: AtttPlayer = Player(idForPlayerX, "PlayerX", symbolForPlayerX)
         private set
-    var B: AtttPlayer = Player(idForPlayerB, "PlayerB", symbolForPlayerB)
+    var O: AtttPlayer = Player(idForPlayerO, "PlayerO", symbolForPlayerO)
         private set
     val None: AtttPlayer = Player(idForPlayerNone, "PlayerNone", symbolForPlayerNone) // one for all cases
 
     // creates new instances for all players for every new GameSession instance
     internal fun prepareNewPlayersInstances() {
-        A = Player(idForPlayerA, "PlayerA", symbolForPlayerA)
-        B = Player(idForPlayerB, "PlayerB", symbolForPlayerB)
+        X = Player(idForPlayerX, "PlayerX", symbolForPlayerX)
+        O = Player(idForPlayerO, "PlayerO", symbolForPlayerO)
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
@@ -15,22 +15,20 @@ private const val symbolForPlayerNone = 'n'
 
 // for now - just the replacement of the former enums use
 internal object PlayerProvider {
-    /*
-        private var idCounter = -1
-        val nextAvailableId: Int
-            get() = idCounter++
-    */
 
     // this is a very temporary solution to just check the failing tests -> then the architecture will get better
-    var X: AtttPlayer = Player(idForPlayerX, "PlayerX", symbolForPlayerX)
+    var X: AtttPlayer = createNewPlayerX()
         private set
-    var O: AtttPlayer = Player(idForPlayerO, "PlayerO", symbolForPlayerO)
+    var O: AtttPlayer = createNewPlayerO()
         private set
     val None: AtttPlayer = Player(idForPlayerNone, "PlayerNone", symbolForPlayerNone) // one for all cases
 
     // creates new instances for all players for every new GameSession instance
     internal fun prepareNewPlayersInstances() {
-        X = Player(idForPlayerX, "PlayerX", symbolForPlayerX)
-        O = Player(idForPlayerO, "PlayerO", symbolForPlayerO)
+        X = createNewPlayerX()
+        O = createNewPlayerO()
     }
+
+    private fun createNewPlayerX() = Player(idForPlayerX, "PlayerX", symbolForPlayerX)
+    private fun createNewPlayerO() = Player(idForPlayerO, "PlayerO", symbolForPlayerO)
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
@@ -16,7 +16,7 @@ private const val symbolForPlayerNone = 'n'
 // for now - just the replacement of the former enums use
 internal object PlayerProvider {
 
-    // this is a very temporary solution to just check the failing tests -> then the architecture will get better
+    // for now, a minimal number of 2 players is enough, but in the future we will have more
     var X: AtttPlayer = createNewPlayerX()
         private set
     var O: AtttPlayer = createNewPlayerO()

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
@@ -8,7 +8,7 @@ interface AtttPlayer {
 
     fun getName(): String?
 
-    fun getSymbol(): Char
+    fun getSymbol(): Char?
 
     fun getMaxLineLength(): Int
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
@@ -4,6 +4,10 @@ import logic.GameSession
 
 interface AtttPlayer {
 
+    fun getId(): Int
+
+    fun getName(): String?
+
     fun getSymbol(): Char
 
     fun getMaxLineLength(): Int

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
@@ -1,6 +1,7 @@
 import elements.Coordinates
 import elements.Player
 import logic.GameSession
+import logic.PlayerProvider
 import utilities.Log
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -34,20 +35,20 @@ class InternalApiTesting {
         // .xo
         // oxo
 
-        game.makeMove(Coordinates(1, 1), Player.A)
-        game.makeMove(Coordinates(2, 1), Player.B)
-        game.makeMove(Coordinates(2, 0), Player.A)
-        game.makeMove(Coordinates(0, 2), Player.B)
-        game.makeMove(Coordinates(1, 2), Player.A)
-        game.makeMove(Coordinates(2, 2), Player.B)
-        game.makeMove(Coordinates(1, 0), Player.A) // here A wins and anyway the next possible player is B
+        game.makeMove(Coordinates(1, 1), PlayerProvider.A)
+        game.makeMove(Coordinates(2, 1), PlayerProvider.B)
+        game.makeMove(Coordinates(2, 0), PlayerProvider.A)
+        game.makeMove(Coordinates(0, 2), PlayerProvider.B)
+        game.makeMove(Coordinates(1, 2), PlayerProvider.A)
+        game.makeMove(Coordinates(2, 2), PlayerProvider.B)
+        game.makeMove(Coordinates(1, 0), PlayerProvider.A) // here A wins and anyway the next possible player is B
 
 //        assertFalse(GameEngine.isActive(), "Game should have been won") -> no more relevant as the API was changed
         assertTrue(game.isGameWon(), "Game should have been won")
         // Would be nice to be able to do this:
         // assertEquals(AtttPlayer.A, AtttEngine.getWinner())
         // -> and yes, this is done:
-        assertEquals(Player.A, game.getWinner())
+        assertEquals(PlayerProvider.A, game.getWinner())
     }
 
     @Test
@@ -60,8 +61,8 @@ class InternalApiTesting {
         game.makeMove(Coordinates(2, 1))
         game.makeMove(Coordinates(1, 2))
         // gameField & winning message for player B is printed in the console
-        assertEquals(Player.B, game.getWinner())
-        assertEquals(Player.A, game.activePlayer) // game is ready for the next potential move in any case
+        assertEquals(PlayerProvider.B, game.getWinner())
+        assertEquals(PlayerProvider.A, game.activePlayer) // game is ready for the next potential move in any case
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 
@@ -75,8 +76,8 @@ class InternalApiTesting {
         game.makeMove(2, 1)
         game.makeMove(1, 2)
         // gameField & winning message for player B is printed in the console
-        assertEquals(Player.B, game.getWinner())
-        assertEquals(Player.A, game.activePlayer) // game is ready for the next potential move in any case
+        assertEquals(PlayerProvider.B, game.getWinner())
+        assertEquals(PlayerProvider.A, game.activePlayer) // game is ready for the next potential move in any case
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
@@ -1,5 +1,4 @@
 import elements.Coordinates
-import elements.Player
 import logic.GameSession
 import logic.PlayerProvider
 import utilities.Log
@@ -35,20 +34,20 @@ class InternalApiTesting {
         // .xo
         // oxo
 
-        game.makeMove(Coordinates(1, 1), PlayerProvider.A)
-        game.makeMove(Coordinates(2, 1), PlayerProvider.B)
-        game.makeMove(Coordinates(2, 0), PlayerProvider.A)
-        game.makeMove(Coordinates(0, 2), PlayerProvider.B)
-        game.makeMove(Coordinates(1, 2), PlayerProvider.A)
-        game.makeMove(Coordinates(2, 2), PlayerProvider.B)
-        game.makeMove(Coordinates(1, 0), PlayerProvider.A) // here A wins and anyway the next possible player is B
+        game.makeMove(Coordinates(1, 1), PlayerProvider.X)
+        game.makeMove(Coordinates(2, 1), PlayerProvider.O)
+        game.makeMove(Coordinates(2, 0), PlayerProvider.X)
+        game.makeMove(Coordinates(0, 2), PlayerProvider.O)
+        game.makeMove(Coordinates(1, 2), PlayerProvider.X)
+        game.makeMove(Coordinates(2, 2), PlayerProvider.O)
+        game.makeMove(Coordinates(1, 0), PlayerProvider.X) // here A wins and anyway the next possible player is B
 
 //        assertFalse(GameEngine.isActive(), "Game should have been won") -> no more relevant as the API was changed
         assertTrue(game.isGameWon(), "Game should have been won")
         // Would be nice to be able to do this:
         // assertEquals(AtttPlayer.A, AtttEngine.getWinner())
         // -> and yes, this is done:
-        assertEquals(PlayerProvider.A, game.getWinner())
+        assertEquals(PlayerProvider.X, game.getWinner())
     }
 
     @Test
@@ -61,8 +60,8 @@ class InternalApiTesting {
         game.makeMove(Coordinates(2, 1))
         game.makeMove(Coordinates(1, 2))
         // gameField & winning message for player B is printed in the console
-        assertEquals(PlayerProvider.B, game.getWinner())
-        assertEquals(PlayerProvider.A, game.activePlayer) // game is ready for the next potential move in any case
+        assertEquals(PlayerProvider.O, game.getWinner())
+        assertEquals(PlayerProvider.X, game.activePlayer) // game is ready for the next potential move in any case
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 
@@ -76,8 +75,8 @@ class InternalApiTesting {
         game.makeMove(2, 1)
         game.makeMove(1, 2)
         // gameField & winning message for player B is printed in the console
-        assertEquals(PlayerProvider.B, game.getWinner())
-        assertEquals(PlayerProvider.A, game.activePlayer) // game is ready for the next potential move in any case
+        assertEquals(PlayerProvider.O, game.getWinner())
+        assertEquals(PlayerProvider.X, game.activePlayer) // game is ready for the next potential move in any case
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
@@ -61,7 +61,7 @@ class InternalApiTesting {
         game.makeMove(Coordinates(1, 2))
         // gameField & winning message for player B is printed in the console
         assertEquals(PlayerProvider.O, game.getWinner())
-        assertEquals(PlayerProvider.X, game.activePlayer) // game is ready for the next potential move in any case
+        assertEquals(PlayerProvider.X, PlayerProvider.activePlayer) // game is ready for the next potential move in any case
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 
@@ -76,7 +76,7 @@ class InternalApiTesting {
         game.makeMove(1, 2)
         // gameField & winning message for player B is printed in the console
         assertEquals(PlayerProvider.O, game.getWinner())
-        assertEquals(PlayerProvider.X, game.activePlayer) // game is ready for the next potential move in any case
+        assertEquals(PlayerProvider.X, PlayerProvider.activePlayer) // game is ready for the next potential move in any case
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -263,11 +263,11 @@ class InternalElementsTesting {
         val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
-        val firstActivePlayer = game.activePlayer // should be player A
+        val firstActivePlayer = PlayerProvider.activePlayer // should be player A
         game.makeMove(firstMark) // after this line active player is replaced with the next -> B
         Log.pl("measuring line from $firstMark for player: $firstActivePlayer in the forward direction:")
         val lengthForPlayerA = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
-        val secondActivePlayer = game.activePlayer // should be player B
+        val secondActivePlayer = PlayerProvider.activePlayer // should be player B
         game.makeMove(secondMark) // after this line active player is replaced with the next -> A
         Log.pl("measuring line from $secondMark for player: $secondActivePlayer in the forward direction:")
         val lengthForPlayerB = game.gameField.measureLineFrom(secondMark, LineDirection.XpY0, 1)
@@ -292,9 +292,9 @@ class InternalElementsTesting {
     fun having3x3Field_TryToSetMarkForThisPlayerOnWrongPosition_currentPlayerRemainsUnchanged() {
         val game = prepareClassic3x3GameField()
         game.makeMove(-1, -1) // attempt to set the mark on a wrong place
-        assertEquals(PlayerProvider.X, game.activePlayer) // this player remains chosen for the next move
+        assertEquals(PlayerProvider.X, PlayerProvider.activePlayer) // this player remains chosen for the next move
         game.makeMove(1, 1) // another attempt for the same player - this time successful
-        assertEquals(PlayerProvider.O, game.activePlayer) // this time the next player is prepared for a move
+        assertEquals(PlayerProvider.O, PlayerProvider.activePlayer) // this time the next player is prepared for a move
         Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
         assertEquals(PlayerProvider.X, game.gameField.getCurrentMarkAt(1, 1))
     }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -1,4 +1,7 @@
-import elements.*
+import elements.Coordinates
+import elements.LineDirection
+import elements.MAX_GAME_FIELD_SIDE_SIZE
+import elements.MIN_GAME_FIELD_SIDE_SIZE
 import logic.GameSession
 import logic.PlayerProvider
 import publicApi.AtttGame
@@ -192,8 +195,8 @@ class InternalElementsTesting {
         val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
-        game.makeMove(firstMark, PlayerProvider.A)
-        game.makeMove(secondMark, PlayerProvider.A)
+        game.makeMove(firstMark, PlayerProvider.X)
+        game.makeMove(secondMark, PlayerProvider.X)
         game.printCurrentFieldIn2d()
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
@@ -208,8 +211,8 @@ class InternalElementsTesting {
         val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
-        game.makeMove(firstMark, PlayerProvider.A)
-        game.makeMove(secondMark, PlayerProvider.A)
+        game.makeMove(firstMark, PlayerProvider.X)
+        game.makeMove(secondMark, PlayerProvider.X)
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
@@ -225,9 +228,9 @@ class InternalElementsTesting {
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
         val connectingMark = Coordinates(1, 0)
-        game.makeMove(firstMark, PlayerProvider.A)
-        game.makeMove(secondMark, PlayerProvider.A)
-        game.makeMove(connectingMark, PlayerProvider.A)
+        game.makeMove(firstMark, PlayerProvider.X)
+        game.makeMove(secondMark, PlayerProvider.X)
+        game.makeMove(connectingMark, PlayerProvider.X)
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
@@ -243,9 +246,9 @@ class InternalElementsTesting {
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
         val oneMoreMark = Coordinates(2, 0)
-        game.makeMove(firstMark, PlayerProvider.A)
-        game.makeMove(secondMark, PlayerProvider.A)
-        game.makeMove(oneMoreMark, PlayerProvider.A)
+        game.makeMove(firstMark, PlayerProvider.X)
+        game.makeMove(secondMark, PlayerProvider.X)
+        game.makeMove(oneMoreMark, PlayerProvider.X)
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromEdgeToEdge = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
@@ -279,21 +282,21 @@ class InternalElementsTesting {
     fun havingOneMarkSetForOnePlayerOn3x3Field_TryToSetMarkForAnotherPlayerInTheSamePlace_previousMarkRemainsUnchanged() {
         val game = prepareClassic3x3GameField()
         val someSpot = Coordinates(1, 1)
-        game.makeMove(someSpot, PlayerProvider.A)
-        game.makeMove(someSpot, PlayerProvider.B)
+        game.makeMove(someSpot, PlayerProvider.X)
+        game.makeMove(someSpot, PlayerProvider.O)
         Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
-        assertEquals(PlayerProvider.A, game.gameField.getCurrentMarkAt(1, 1))
+        assertEquals(PlayerProvider.X, game.gameField.getCurrentMarkAt(1, 1))
     }
 
     @Test
     fun having3x3Field_TryToSetMarkForThisPlayerOnWrongPosition_currentPlayerRemainsUnchanged() {
         val game = prepareClassic3x3GameField()
         game.makeMove(-1, -1) // attempt to set the mark on a wrong place
-        assertEquals(PlayerProvider.A, game.activePlayer) // this player remains chosen for the next move
+        assertEquals(PlayerProvider.X, game.activePlayer) // this player remains chosen for the next move
         game.makeMove(1, 1) // another attempt for the same player - this time successful
-        assertEquals(PlayerProvider.B, game.activePlayer) // this time the next player is prepared for a move
+        assertEquals(PlayerProvider.O, game.activePlayer) // this time the next player is prepared for a move
         Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
-        assertEquals(PlayerProvider.A, game.gameField.getCurrentMarkAt(1, 1))
+        assertEquals(PlayerProvider.X, game.gameField.getCurrentMarkAt(1, 1))
     }
 
     @Test
@@ -301,32 +304,28 @@ class InternalElementsTesting {
         println("having3x3Field_onlyOnePlayerMarksAreSet_victoryConditionIsCorrect")
         val atttGame = AtttGame.create(3, 3)
         val game = atttGame as GameSession
-        game.makeMove(Coordinates(0, 0), PlayerProvider.A)
-        game.makeMove(Coordinates(1, 0), PlayerProvider.A)
+        game.makeMove(Coordinates(0, 0), PlayerProvider.X)
+        game.makeMove(Coordinates(1, 0), PlayerProvider.X)
         println(game.getWinner().getMaxLineLength())
         println(game.getLeader().getMaxLineLength())
-        game.makeMove(Coordinates(2, 0), PlayerProvider.A)
+        game.makeMove(Coordinates(2, 0), PlayerProvider.X)
         // gameField & winning message for player A is printed in the console
-        assertEquals(PlayerProvider.A, game.getWinner())
+        assertEquals(PlayerProvider.X, game.getWinner())
         println("3x3 Player.A: ${game.getWinner().hashCode()}")
-        assertEquals(
-            3,
-            game.getWinner().getMaxLineLength()
-        ) // actual 5 when this test is launched in scope with others
-        // todo: fix
+        assertEquals(3, game.getWinner().getMaxLineLength())
     }
 
     @Test
     fun having2LinesOfOnePlayerOn5x5Field_thisPlayerMarkIsSetInBetween_victoryConditionIsCorrect() {
         val game = GameSession(5, 5)
         Log.pl("\ntest5x5Field: gameEngine ready with given field: ${game.gameField.prepareForPrintingIn2d()}")
-        game.makeMove(Coordinates(0, 0), PlayerProvider.A)
-        game.makeMove(Coordinates(1, 0), PlayerProvider.A)
+        game.makeMove(Coordinates(0, 0), PlayerProvider.X)
+        game.makeMove(Coordinates(1, 0), PlayerProvider.X)
         // GameEngine.makeNewMove(Coordinates(2, 0), WhichPlayer.A) // intentionally commented - it will be used a bit later
-        game.makeMove(Coordinates(3, 0), PlayerProvider.A)
-        game.makeMove(Coordinates(4, 0), PlayerProvider.A)
-        game.makeMove(Coordinates(2, 0), PlayerProvider.A) // intentionally placed here to connect 2 segments
-        assertEquals(PlayerProvider.A, game.getWinner())
+        game.makeMove(Coordinates(3, 0), PlayerProvider.X)
+        game.makeMove(Coordinates(4, 0), PlayerProvider.X)
+        game.makeMove(Coordinates(2, 0), PlayerProvider.X) // intentionally placed here to connect 2 segments
+        assertEquals(PlayerProvider.X, game.getWinner())
         println("5x5 Player.A: ${game.getWinner().hashCode()}")
         assertEquals(5, game.getWinner().getMaxLineLength())
     }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -1,5 +1,6 @@
 import elements.*
 import logic.GameSession
+import logic.PlayerProvider
 import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.BeforeTest
@@ -191,8 +192,8 @@ class InternalElementsTesting {
         val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
-        game.makeMove(firstMark, Player.A)
-        game.makeMove(secondMark, Player.A)
+        game.makeMove(firstMark, PlayerProvider.A)
+        game.makeMove(secondMark, PlayerProvider.A)
         game.printCurrentFieldIn2d()
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
@@ -207,8 +208,8 @@ class InternalElementsTesting {
         val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
-        game.makeMove(firstMark, Player.A)
-        game.makeMove(secondMark, Player.A)
+        game.makeMove(firstMark, PlayerProvider.A)
+        game.makeMove(secondMark, PlayerProvider.A)
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
@@ -224,9 +225,9 @@ class InternalElementsTesting {
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
         val connectingMark = Coordinates(1, 0)
-        game.makeMove(firstMark, Player.A)
-        game.makeMove(secondMark, Player.A)
-        game.makeMove(connectingMark, Player.A)
+        game.makeMove(firstMark, PlayerProvider.A)
+        game.makeMove(secondMark, PlayerProvider.A)
+        game.makeMove(connectingMark, PlayerProvider.A)
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
@@ -242,9 +243,9 @@ class InternalElementsTesting {
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
         val oneMoreMark = Coordinates(2, 0)
-        game.makeMove(firstMark, Player.A)
-        game.makeMove(secondMark, Player.A)
-        game.makeMove(oneMoreMark, Player.A)
+        game.makeMove(firstMark, PlayerProvider.A)
+        game.makeMove(secondMark, PlayerProvider.A)
+        game.makeMove(oneMoreMark, PlayerProvider.A)
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromEdgeToEdge = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
@@ -278,21 +279,21 @@ class InternalElementsTesting {
     fun havingOneMarkSetForOnePlayerOn3x3Field_TryToSetMarkForAnotherPlayerInTheSamePlace_previousMarkRemainsUnchanged() {
         val game = prepareClassic3x3GameField()
         val someSpot = Coordinates(1, 1)
-        game.makeMove(someSpot, Player.A)
-        game.makeMove(someSpot, Player.B)
+        game.makeMove(someSpot, PlayerProvider.A)
+        game.makeMove(someSpot, PlayerProvider.B)
         Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
-        assertEquals(Player.A, game.gameField.getCurrentMarkAt(1, 1))
+        assertEquals(PlayerProvider.A, game.gameField.getCurrentMarkAt(1, 1))
     }
 
     @Test
     fun having3x3Field_TryToSetMarkForThisPlayerOnWrongPosition_currentPlayerRemainsUnchanged() {
         val game = prepareClassic3x3GameField()
         game.makeMove(-1, -1) // attempt to set the mark on a wrong place
-        assertEquals(Player.A, game.activePlayer) // this player remains chosen for the next move
+        assertEquals(PlayerProvider.A, game.activePlayer) // this player remains chosen for the next move
         game.makeMove(1, 1) // another attempt for the same player - this time successful
-        assertEquals(Player.B, game.activePlayer) // this time the next player is prepared for a move
+        assertEquals(PlayerProvider.B, game.activePlayer) // this time the next player is prepared for a move
         Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
-        assertEquals(Player.A, game.gameField.getCurrentMarkAt(1, 1))
+        assertEquals(PlayerProvider.A, game.gameField.getCurrentMarkAt(1, 1))
     }
 
     @Test
@@ -300,13 +301,13 @@ class InternalElementsTesting {
         println("having3x3Field_onlyOnePlayerMarksAreSet_victoryConditionIsCorrect")
         val atttGame = AtttGame.create(3, 3)
         val game = atttGame as GameSession
-        game.makeMove(Coordinates(0, 0), Player.A)
-        game.makeMove(Coordinates(1, 0), Player.A)
+        game.makeMove(Coordinates(0, 0), PlayerProvider.A)
+        game.makeMove(Coordinates(1, 0), PlayerProvider.A)
         println(game.getWinner().getMaxLineLength())
         println(game.getLeader().getMaxLineLength())
-        game.makeMove(Coordinates(2, 0), Player.A)
+        game.makeMove(Coordinates(2, 0), PlayerProvider.A)
         // gameField & winning message for player A is printed in the console
-        assertEquals(Player.A, game.getWinner())
+        assertEquals(PlayerProvider.A, game.getWinner())
         println("3x3 Player.A: ${game.getWinner().hashCode()}")
         assertEquals(
             3,
@@ -319,13 +320,13 @@ class InternalElementsTesting {
     fun having2LinesOfOnePlayerOn5x5Field_thisPlayerMarkIsSetInBetween_victoryConditionIsCorrect() {
         val game = GameSession(5, 5)
         Log.pl("\ntest5x5Field: gameEngine ready with given field: ${game.gameField.prepareForPrintingIn2d()}")
-        game.makeMove(Coordinates(0, 0), Player.A)
-        game.makeMove(Coordinates(1, 0), Player.A)
+        game.makeMove(Coordinates(0, 0), PlayerProvider.A)
+        game.makeMove(Coordinates(1, 0), PlayerProvider.A)
         // GameEngine.makeNewMove(Coordinates(2, 0), WhichPlayer.A) // intentionally commented - it will be used a bit later
-        game.makeMove(Coordinates(3, 0), Player.A)
-        game.makeMove(Coordinates(4, 0), Player.A)
-        game.makeMove(Coordinates(2, 0), Player.A) // intentionally placed here to connect 2 segments
-        assertEquals(Player.A, game.getWinner())
+        game.makeMove(Coordinates(3, 0), PlayerProvider.A)
+        game.makeMove(Coordinates(4, 0), PlayerProvider.A)
+        game.makeMove(Coordinates(2, 0), PlayerProvider.A) // intentionally placed here to connect 2 segments
+        assertEquals(PlayerProvider.A, game.getWinner())
         println("5x5 Player.A: ${game.getWinner().hashCode()}")
         assertEquals(5, game.getWinner().getMaxLineLength())
     }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
@@ -1,4 +1,3 @@
-import elements.Player
 import logic.PlayerProvider
 import utilities.Log
 import kotlin.test.BeforeTest
@@ -33,7 +32,7 @@ class PublicApiTesting {
         game.mm(1, 0) // X - this one was problematic but in version 0.3.0 this bug was fixed
 
         assertTrue(game.isGameWon(), "Game should have been won")
-        assertEquals(PlayerProvider.A, game.getWinner())
+        assertEquals(PlayerProvider.X, game.getWinner())
     }
 
     @Test
@@ -42,7 +41,7 @@ class PublicApiTesting {
         game.mm(0, 0) // A
         game.mm(1, 0) // B
         game.mm(0, 1) // A -> now A has a line of 2 marks
-        assertEquals(PlayerProvider.A, game.getLeader())
+        assertEquals(PlayerProvider.X, game.getLeader())
         assertEquals(2, game.getLeader().getMaxLineLength())
     }
 
@@ -61,7 +60,7 @@ class PublicApiTesting {
         game.mm(1, 1) // B -> now B also has a line of 2 marks
         game.mm(2, 0) // A -> now A still has a line of 2 marks
         game.mm(1, 2) // A -> now B has a line of 3 marks and becomes a new leader
-        assertEquals(PlayerProvider.B, game.getLeader())
+        assertEquals(PlayerProvider.O, game.getLeader())
         assertEquals(3, game.getLeader().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
@@ -1,4 +1,5 @@
 import elements.Player
+import logic.PlayerProvider
 import utilities.Log
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -32,7 +33,7 @@ class PublicApiTesting {
         game.mm(1, 0) // X - this one was problematic but in version 0.3.0 this bug was fixed
 
         assertTrue(game.isGameWon(), "Game should have been won")
-        assertEquals(Player.A, game.getWinner())
+        assertEquals(PlayerProvider.A, game.getWinner())
     }
 
     @Test
@@ -41,7 +42,7 @@ class PublicApiTesting {
         game.mm(0, 0) // A
         game.mm(1, 0) // B
         game.mm(0, 1) // A -> now A has a line of 2 marks
-        assertEquals(Player.A, game.getLeader())
+        assertEquals(PlayerProvider.A, game.getLeader())
         assertEquals(2, game.getLeader().getMaxLineLength())
     }
 
@@ -60,7 +61,7 @@ class PublicApiTesting {
         game.mm(1, 1) // B -> now B also has a line of 2 marks
         game.mm(2, 0) // A -> now A still has a line of 2 marks
         game.mm(1, 2) // A -> now B has a line of 3 marks and becomes a new leader
-        assertEquals(Player.B, game.getLeader())
+        assertEquals(PlayerProvider.B, game.getLeader())
         assertEquals(3, game.getLeader().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
@@ -1,8 +1,8 @@
 import elements.Border
 import elements.Coordinates
 import elements.LineDirection
-import logic.GameSession
 import logic.GameField
+import logic.GameSession
 import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.assertEquals


### PR DESCRIPTION
problem was related to using the same enum class instances for different game sessions/launches.
here it's fixed & tests now are 100% green.