### PR TITLE
enable any reasonable number of players instead of only two

### DIFF
--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Limitations.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Limitations.kt
@@ -18,4 +18,4 @@ internal const val MAX_GAME_FIELD_DIMENSIONS = 3 // what if we want a 3d? this c
 
 // default size for AtttField creation
 internal const val MIN_NUMBER_OF_PLAYERS = 2 // the game has no sense if less
-internal const val MAX_NUMBER_OF_PLAYERS = 1000 // let's imagine this engine once works for an online multiplayer game
+internal const val MAX_NUMBER_OF_PLAYERS = 90 // because ASCII visible basic symbols excluding ' ` . and _

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
@@ -2,8 +2,8 @@ package elements
 
 import publicApi.AtttPlayer
 
-internal class Player(
-    private val id: Int, private val name: String? = null, private val symbol: Char? = null
+internal data class Player(
+    private val id: Int, private var name: String? = null, private var symbol: Char? = null
 ) : AtttPlayer {
 
     private var maxLineLength = 0 // not using get & set here as this data is accessed from AtttPlayer interface

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
@@ -6,6 +6,13 @@ internal data class Player(
     private val id: Int, private var name: String? = null, private var symbol: Char? = null
 ) : AtttPlayer {
 
+    init {
+        if (name.isNullOrBlank()) name = "Player # $id"
+        if (symbol == null || symbol?.isWhitespace() == true) {
+            symbol = definePlayerSymbolById()
+        }
+    }
+
     private var maxLineLength = 0 // not using get & set here as this data is accessed from AtttPlayer interface
 
     override fun getId(): Int = id // this is the main criterion to distinguish one player from any other

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/elements/Player.kt
@@ -19,4 +19,30 @@ internal data class Player(
     internal fun tryToSetMaxLineLength(newLineLength: Int) {
         if (newLineLength > maxLineLength) maxLineLength = newLineLength
     }
+
+    private fun definePlayerSymbolById(): Char {
+        // let's do it with ASCII table - all following numbers are decimal for simplicity
+        val asciiCode = if (id < 10) {
+            id + '0'.code // 0...9
+        } else if (id < 10 + 26) { // id: 10...35 -> capital letters
+            id + 'A'.code // A...Z
+        } else if (id < 10 + 26 + 26) { // id: 36...61 -> small letters
+            id + 'a'.code // a...z
+        } else if (id < 10 + 26 + 26 + 6) { // id: 62...67 -> signs from ! to & including both
+            id + '!'.code // ! " # $ % &
+        } else if (id < 10 + 26 + 26 + 6 + 6) { // id: 68...73 -> signs from ( to - including both
+            id + '('.code // ( ) * + , -
+        } else if (id < 10 + 26 + 26 + 6 + 6 + 1) { // id = 74 -> sign /
+            id + '/'.code
+        } else if (id < 10 + 26 + 26 + 6 + 6 + 1 + 7) { // id: 75...81 -> signs from : to @
+            id + ':'.code // : ; < = > ? @
+        } else if (id < 10 + 26 + 26 + 6 + 6 + 1 + 7 + 4) { // id: 82...85 -> signs from [ to ^
+            id + '['.code // [ \ ] ^
+        } else if (id < 10 + 26 + 26 + 6 + 6 + 1 + 7 + 4 + 4) { // id: 86...89 -> signs from { to ~
+            id + '{'.code // { | } ~
+        } else { // id: 90+ -> but this case should not be accessible because
+            '_'.code // _
+        }
+        return asciiCode.toChar()
+    }
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameRules.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameRules.kt
@@ -13,7 +13,7 @@ internal class GameRules(
 ) {
     private val maxLines: MutableMap<AtttPlayer, Int> = mutableMapOf()
 
-    private var theWinner: AtttPlayer? = null
+    private var theWinner: AtttPlayer = PlayerProvider.None
 
     init {
         // here we're doing possible corrections that may be needed to keep the game rules reasonable
@@ -21,9 +21,9 @@ internal class GameRules(
         else if (winningLength < MIN_WINNING_LINE_LENGTH) winningLength = MIN_WINNING_LINE_LENGTH
     }
 
-    internal fun isGameWon(): Boolean = theWinner != null
+    internal fun isGameWon(): Boolean = theWinner != PlayerProvider.None
 
-    internal fun getWinner(): AtttPlayer? = theWinner
+    internal fun getWinner(): AtttPlayer = theWinner
 
     internal fun getLeadingPlayer(): AtttPlayer = detectLeadingPlayer() ?: PlayerProvider.None
 
@@ -31,7 +31,7 @@ internal class GameRules(
     private fun detectLeadingPlayer(): AtttPlayer? = maxLines.entries.maxByOrNull { k -> k.value }?.key
 
     internal fun updatePlayerScore(whichPlayer: AtttPlayer, newLineLength: Int) {
-        if (theWinner != null) return // do NOT make any changes to
+        if (isGameWon()) return // I decided to preserve the state of gameField when the winner is detected
         // the following lines work only when the winner has NOT been yet detected
         if (newLineLength > (maxLines[whichPlayer] ?: 0)) {
             maxLines[whichPlayer] = newLineLength

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -11,13 +11,13 @@ import utilities.Log
  * a game session can be started & finished, each time new to be clear from any possible remains.
  */
 @Suppress("unused", "MemberVisibilityCanBePrivate")
-class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int) : AtttGame {
+class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int, desiredPlayerNumber: Int) : AtttGame {
 
     internal var gameField: GameField = GameField(desiredFieldSize)
     private var gameRules: GameRules = GameRules(desiredMaxLineLength)
 
     init {
-        PlayerProvider.prepareNewPlayersInstances()
+        PlayerProvider.prepareNewPlayersInstances(desiredPlayerNumber)
         PlayerProvider.presetNextPlayer() // this invocation sets the activePlayer to the starting Player among others
     }
 

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/GameSession.kt
@@ -49,7 +49,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int, desiredPlaye
             val maxLengthForThisMove = existingLineDirections.maxOfOrNull { lineDirection ->
                 gameField.measureFullLengthForExistingLineFrom(where, lineDirection)
             }
-            Log.pl("makeMove: maxLength for this move of player $what is: $maxLengthForThisMove")
+            Log.pl("makeMove: maxLength for this move of player ${what.getName()} is: $maxLengthForThisMove")
             maxLengthForThisMove?.let {
                 (what as Player).tryToSetMaxLineLength(it) // this cast is secure as Player is direct inheritor to AtttPlayer
                 updateGameScore(what, it)
@@ -67,7 +67,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int, desiredPlaye
     /**
      * there can be only one winner - Player.None is returned until the winner not yet detected
      */
-    override fun getWinner(): AtttPlayer = gameRules.getWinner() ?: PlayerProvider.None
+    override fun getWinner(): AtttPlayer = gameRules.getWinner()
 
     /**
      * after the winner is detected there is no way to modify the game field, so the game state is preserved
@@ -78,6 +78,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int, desiredPlaye
      * prints the current state of the game in 2d on console
      */
     override fun printCurrentFieldIn2d() {
+        // not using Log.pl here as this action is intentional & has not be able to switch off
         println(gameField.prepareForPrintingIn2d())
     }
 
@@ -91,7 +92,7 @@ class GameSession(desiredFieldSize: Int, desiredMaxLineLength: Int, desiredPlaye
     private fun updateGameScore(whichPlayer: AtttPlayer, detectedLineLength: Int) {
         gameRules.updatePlayerScore(whichPlayer, detectedLineLength)
         if (gameRules.isGameWon()) {
-            Log.pl("player ${gameRules.getWinner()} wins with detectedLineLength: $detectedLineLength")
+            Log.pl("player ${gameRules.getWinner().getId()} wins with detectedLineLength: $detectedLineLength")
         }
     }
 

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/logic/PlayerProvider.kt
@@ -1,46 +1,69 @@
 package logic
 
+import elements.MAX_NUMBER_OF_PLAYERS
+import elements.MIN_NUMBER_OF_PLAYERS
 import elements.Player
 import publicApi.AtttPlayer
+import utilities.Log
 
 internal const val SYMBOL_FOR_ABSENT_MARK = '·'
 
-private const val idForPlayerX = 42 // of course, you know why exactly 42 :)
-private const val idForPlayerO = 0
+private const val idForPlayerX = 0 // because by convention X is the first
+private const val idForPlayerO = 1 // by convention O goes only after X
 private const val idForPlayerNone = -1
 
 private const val symbolForPlayerX = 'X'
 private const val symbolForPlayerO = 'O'
-private const val symbolForPlayerNone = 'n'
+private const val symbolForPlayerNone = '_' // just for case but this should not be ever shown on the game field
 
 // for now - just the replacement of the former enums use
 internal object PlayerProvider {
 
-    // for now, a minimal number of 2 players is enough, but in the future we will have more
-    var X: AtttPlayer = createNewPlayerX()
-        private set
-    var O: AtttPlayer = createNewPlayerO()
-        private set
     val None: AtttPlayer = Player(idForPlayerNone, "PlayerNone", symbolForPlayerNone) // one for all cases
 
     // this is a part of inner game logic - it should be used only internally, for now there's no need to show it to a client
     internal var activePlayer: AtttPlayer = None
         private set
 
-    // creates new instances for all players for every new GameSession instance
-    internal fun prepareNewPlayersInstances() {
-        X = createNewPlayerX()
-        O = createNewPlayerO()
+    private var numberOfPlayersInGameSession: Int = -1 // real value cannot be less than 2 and more than 90 for now
+
+    internal var playersList: MutableList<Player> = mutableListOf()
+
+    /**
+     * resets the activePlayer and creates new instances for all players for every new GameSession instance
+     */
+    internal fun prepareNewPlayersInstances(desiredNumberOfPlayers: Int) {
+        activePlayer = None
+        Log.pl("prepareNewPlayersInstances: desiredNumberOfPlayers = $desiredNumberOfPlayers")
+        numberOfPlayersInGameSession = when {
+            desiredNumberOfPlayers > MAX_NUMBER_OF_PLAYERS -> MAX_NUMBER_OF_PLAYERS
+            desiredNumberOfPlayers < MIN_NUMBER_OF_PLAYERS -> MIN_NUMBER_OF_PLAYERS
+            else -> desiredNumberOfPlayers
+        }
+        Log.pl("prepareNewPlayersInstances: numberOfPlayersInGameSession = $numberOfPlayersInGameSession")
+        playersList = ArrayList(numberOfPlayersInGameSession)
+        if (numberOfPlayersInGameSession == MIN_NUMBER_OF_PLAYERS) { // default case for a classic Crosses & Noughts game
+            playersList.add(0, Player(idForPlayerX, "PlayerX", symbolForPlayerX)) // usually goes first
+            playersList.add(1, Player(idForPlayerO, "PlayerO", symbolForPlayerO)) // usually goes after X
+        } else { // more than 2 players
+            (0 until numberOfPlayersInGameSession).forEachIndexed { index, _ ->
+                playersList.add(index, Player(index))
+            }
+        }
+        Log.pl("prepareNewPlayersInstances: playersList = $playersList")
     }
 
     /**
      * sets the currently active player, for which a move will be made & returns the player for the next move
      */
     internal fun presetNextPlayer(): AtttPlayer {
-        activePlayer = if (activePlayer == X) O else X // A is set after None & null case as well
+        // Assignments are not expressions, and only expressions are allowed in this context
+        activePlayer =
+            if (activePlayer == playersList.last() || activePlayer == None) { // any possible edge case -> select the first
+                playersList.first() // we need a ring here to make this carousel infinite
+            } else {
+                playersList[activePlayer.getId() + 1] // normal case in the middle of a game -> just pick the next one
+            }
         return activePlayer
     }
-
-    private fun createNewPlayerX() = Player(idForPlayerX, "PlayerX", symbolForPlayerX)
-    private fun createNewPlayerO() = Player(idForPlayerO, "PlayerO", symbolForPlayerO)
 }

--- a/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
+++ b/Attt_LocalEngine_Kotlin/src/main/kotlin/publicApi/Interfaces.kt
@@ -1,5 +1,6 @@
 package publicApi
 
+import elements.MIN_NUMBER_OF_PLAYERS
 import logic.GameSession
 
 interface AtttPlayer {
@@ -31,7 +32,8 @@ interface AtttGame {
         /**
          * create AtttGame instance & provide the UI with a new game field, adjustability happens here - in the parameters
          */
-        fun create(desiredFieldSize: Int, desiredMaxLineLength: Int): AtttGame =
-            GameSession(desiredFieldSize, desiredMaxLineLength)
+        fun create(
+            desiredFieldSize: Int, desiredMaxLineLength: Int, desiredPlayerNumber: Int = MIN_NUMBER_OF_PLAYERS
+        ): AtttGame = GameSession(desiredFieldSize, desiredMaxLineLength, desiredPlayerNumber)
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
@@ -28,55 +28,67 @@ class InternalApiTesting {
     // this test was provided by Matt Tucker - https://github.com/tuck182 - many thanks for finding a serious bug!
     @Test
     fun test3x3FieldWithMultiplePossibleLines() { // test name is left as it was in the pull-request
-        val game = GameSession(3, 3)
+        val game = GameSession(3, 3, 2)
+        val playerX = PlayerProvider.playersList[0]
+        val playerO = PlayerProvider.playersList[1]
 
         // .Xx
         // .xo
         // oxo
 
-        game.makeMove(Coordinates(1, 1), PlayerProvider.X)
-        game.makeMove(Coordinates(2, 1), PlayerProvider.O)
-        game.makeMove(Coordinates(2, 0), PlayerProvider.X)
-        game.makeMove(Coordinates(0, 2), PlayerProvider.O)
-        game.makeMove(Coordinates(1, 2), PlayerProvider.X)
-        game.makeMove(Coordinates(2, 2), PlayerProvider.O)
-        game.makeMove(Coordinates(1, 0), PlayerProvider.X) // here A wins and anyway the next possible player is B
+        game.makeMove(Coordinates(1, 1), playerX)
+        game.makeMove(Coordinates(2, 1), playerO)
+        game.makeMove(Coordinates(2, 0), playerX)
+        game.makeMove(Coordinates(0, 2), playerO)
+        game.makeMove(Coordinates(1, 2), playerX)
+        game.makeMove(Coordinates(2, 2), playerO)
+        game.makeMove(Coordinates(1, 0), playerX) // here A wins and anyway the next possible player is B
 
 //        assertFalse(GameEngine.isActive(), "Game should have been won") -> no more relevant as the API was changed
         assertTrue(game.isGameWon(), "Game should have been won")
         // Would be nice to be able to do this:
         // assertEquals(AtttPlayer.A, AtttEngine.getWinner())
         // -> and yes, this is done:
-        assertEquals(PlayerProvider.X, game.getWinner())
+        assertEquals(playerX, game.getWinner())
     }
 
     @Test
     fun having3x3Field_realSimulation2PlayersMovesMade_victoryConditionIsCorrect() {
-        val game = prepareClassic3x3GameField()
-        game.makeMove(Coordinates(0, 0))
-        game.makeMove(Coordinates(1, 0))
-        game.makeMove(Coordinates(2, 0))
-        game.makeMove(Coordinates(1, 1))
-        game.makeMove(Coordinates(2, 1))
-        game.makeMove(Coordinates(1, 2))
+        val game = GameSession(3, 3, 2)
+        game.makeMove(Coordinates(0, 0)) // X
+        game.makeMove(Coordinates(1, 0)) // O
+        game.makeMove(Coordinates(2, 0)) // X
+        game.makeMove(Coordinates(1, 1)) // O
+        game.makeMove(Coordinates(2, 1)) // X
+        game.makeMove(Coordinates(1, 2)) // O - > O wins here
+        /*
+            X O X
+            . O X
+            . O .
+         */
+        game.printCurrentFieldIn2d()
         // gameField & winning message for player B is printed in the console
-        assertEquals(PlayerProvider.O, game.getWinner())
-        assertEquals(PlayerProvider.X, PlayerProvider.activePlayer) // game is ready for the next potential move in any case
+        val playerX = PlayerProvider.playersList[0]
+        val playerO = PlayerProvider.playersList[1]
+        assertEquals(playerO, game.getWinner())
+        assertEquals(playerX, PlayerProvider.activePlayer) // game is ready for the next potential move in any case
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 
     @Test
     fun having3x3Field_realSimulation2PlayersShortenedMovesMade_victoryConditionIsCorrect() {
-        val game = prepareClassic3x3GameField()
-        game.makeMove(0, 0)
-        game.makeMove(1, 0)
-        game.makeMove(2, 0)
-        game.makeMove(1, 1)
-        game.makeMove(2, 1)
-        game.makeMove(1, 2)
+        val game = GameSession(3, 3, 2)
+        val playerX = PlayerProvider.playersList[0]
+        val playerO = PlayerProvider.playersList[1]
+        game.makeMove(0, 0) // X
+        game.makeMove(1, 0) // O
+        game.makeMove(2, 0) // X
+        game.makeMove(1, 1) // O
+        game.makeMove(2, 1) // X
+        game.makeMove(1, 2) // O
         // gameField & winning message for player B is printed in the console
-        assertEquals(PlayerProvider.O, game.getWinner())
-        assertEquals(PlayerProvider.X, PlayerProvider.activePlayer) // game is ready for the next potential move in any case
+        assertEquals(playerO, game.getWinner())
+        assertEquals(playerX, PlayerProvider.activePlayer) // game is ready for the next potential move in any case
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalApiTesting.kt
@@ -14,17 +14,6 @@ class InternalApiTesting {
         Log.switch(true)
     }
 
-    /*
-        @Test
-        fun havingUnpreparedField_aPlayerTriesToMakeMove_noMoveIsMadeOnUnpreparedField() {
-            val game = AtttGame.create()
-            (game as GameEngine).makeMove(Coordinates(0, 0))
-            assertEquals(Player.None, game.getLeader())
-            assertEquals(0, game.getLeader().getMaxLineLength())
-            // so it's impossible to play game BEFORE prepare() is invoked
-        }
-    */
-
     // this test was provided by Matt Tucker - https://github.com/tuck182 - many thanks for finding a serious bug!
     @Test
     fun test3x3FieldWithMultiplePossibleLines() { // test name is left as it was in the pull-request
@@ -44,7 +33,6 @@ class InternalApiTesting {
         game.makeMove(Coordinates(2, 2), playerO)
         game.makeMove(Coordinates(1, 0), playerX) // here A wins and anyway the next possible player is B
 
-//        assertFalse(GameEngine.isActive(), "Game should have been won") -> no more relevant as the API was changed
         assertTrue(game.isGameWon(), "Game should have been won")
         // Would be nice to be able to do this:
         // assertEquals(AtttPlayer.A, AtttEngine.getWinner())

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -22,7 +22,8 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_classic3x3GameIsCreated_classic3x3GameFieldIsReady() {
         val game = GameSession(3, 3, 2)
-        assertTrue(isGameFieldReady(game.gameField))
+        assertTrue(game.gameField.isReady())
+        assertFalse(game.isGameWon())
     }
 
     @Test

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -5,10 +5,7 @@ import elements.MIN_GAME_FIELD_SIDE_SIZE
 import logic.GameSession
 import logic.PlayerProvider
 import utilities.Log
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class InternalElementsTesting {
 
@@ -30,8 +27,8 @@ class InternalElementsTesting {
     fun gameIsNotStarted_gameFieldOfAnyCorrectSizeIsCreated_gameFieldWithSpecifiedSizeIsReady() {
         val game = GameSession(7, 5, 2)
         Log.pl("\ngameEngine is ready having this field: ${game.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(game.gameField))
-        assertEquals(7, getGameFieldSideLength(game.gameField))
+        assertTrue(game.gameField.isReady())
+        assertEquals(7, game.gameField.sideLength)
     }
 
     @Test
@@ -39,23 +36,23 @@ class InternalElementsTesting {
         // size = maxLength = 2 -> game would have no sense in this case, the same as with field size of 1
         val game2x2 = GameSession(2, 2, 2)
         Log.pl("\ngameEngine is ready having this field: ${game2x2.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(game2x2.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game2x2.gameField))
+        assertTrue(game2x2.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, game2x2.gameField.sideLength)
         // size = maxLength = 0
         val game0x0 = GameSession(0, 0, 2)
         Log.pl("\ngameEngine is ready having this field: ${game0x0.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(game0x0.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game0x0.gameField))
+        assertTrue(game0x0.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, game0x0.gameField.sideLength)
         // size = maxLength = -1
         val gameM1M1 = GameSession(-1, -1, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameM1M1.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameM1M1.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameM1M1.gameField))
+        assertTrue(gameM1M1.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameM1M1.gameField.sideLength)
         // size = maxLength = Int.MIN_VALUE
         val gameMxM = GameSession(Int.MIN_VALUE, Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMxM.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMxM.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMxM.gameField))
+        assertTrue(gameMxM.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameMxM.gameField.sideLength)
     }
 
     @Test
@@ -63,13 +60,13 @@ class InternalElementsTesting {
         // size = maxLength = 1001 -> for now the limit is set to 1000 dots per side but in the future there could be more
         val game1k1 = GameSession(1001, 1001, 2)
         Log.pl("\ngameEngine is ready having this field: ${game1k1.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(game1k1.gameField))
-        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game1k1.gameField))
+        assertTrue(game1k1.gameField.isReady())
+        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, game1k1.gameField.sideLength)
         // size = maxLength = Int.MAX_VALUE
         val gameMM = GameSession(Int.MAX_VALUE, Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMM.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMM.gameField))
-        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMM.gameField))
+        assertTrue(gameMM.gameField.isReady())
+        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, gameMM.gameField.sideLength)
     }
 
     @Suppress("INTEGER_OVERFLOW")
@@ -78,8 +75,8 @@ class InternalElementsTesting {
         // size = maxLength tries to be less than Int.MIN_VALUE -> there will be overflow of the Int
         val game = GameSession(Int.MIN_VALUE - 1, Int.MIN_VALUE - 1, 2)
         Log.pl("\ngameEngine is ready having this field: ${game.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(game.gameField))
-        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
+        assertTrue(game.gameField.isReady())
+        assertEquals(MAX_GAME_FIELD_SIDE_SIZE, game.gameField.sideLength)
     }
 
     @Suppress("INTEGER_OVERFLOW")
@@ -88,8 +85,8 @@ class InternalElementsTesting {
         // size = maxLength tries to be more than Int.MAX_VALUE -> there will be overflow of the Int
         val game = GameSession(Int.MAX_VALUE + 1, Int.MAX_VALUE + 1, 2)
         Log.pl("\ngameEngine is ready having this field: ${game.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(game.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
+        assertTrue(game.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, game.gameField.sideLength)
     }
 
     // assertions of this test are made mostly to see interesting effects during different kinds of limits mixing
@@ -99,57 +96,57 @@ class InternalElementsTesting {
         // size = maxLength = Int.MIN_VALUE + Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
         val gameMinPlusMin = GameSession(Int.MIN_VALUE + Int.MIN_VALUE, Int.MIN_VALUE + Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMin.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMinPlusMin.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMin.gameField))
+        assertTrue(gameMinPlusMin.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameMinPlusMin.gameField.sideLength)
         println(Int.MIN_VALUE + Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
         val gameMinMinusMin = GameSession(Int.MIN_VALUE - Int.MIN_VALUE, Int.MIN_VALUE - Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMin.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMinMinusMin.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMin.gameField))
+        assertTrue(gameMinMinusMin.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameMinMinusMin.gameField.sideLength)
         println(Int.MIN_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MAX_VALUE = -2 in fact - this is an interesting effect of the Int
         val gameMaxPlusMax = GameSession(Int.MAX_VALUE + Int.MAX_VALUE, Int.MAX_VALUE + Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMax.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMaxPlusMax.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMax.gameField))
+        assertTrue(gameMaxPlusMax.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameMaxPlusMax.gameField.sideLength)
         println(Int.MAX_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MAX_VALUE = 0 which is obvious
         val gameMaxMinusMax = GameSession(Int.MAX_VALUE - Int.MAX_VALUE, Int.MAX_VALUE - Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMax.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMaxMinusMax.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMax.gameField))
+        assertTrue(gameMaxMinusMax.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameMaxMinusMax.gameField.sideLength)
         println(Int.MAX_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MAX_VALUE = +1 in fact - this is an interesting effect of the Int
         val gameMinMinusMax = GameSession(Int.MIN_VALUE - Int.MAX_VALUE, Int.MIN_VALUE - Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMax.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMinMinusMax.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMax.gameField))
+        assertTrue(gameMinMinusMax.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameMinMinusMax.gameField.sideLength)
         println(Int.MIN_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MIN_VALUE = -1 which is obvious
         val gameMaxMinusMin = GameSession(Int.MAX_VALUE - Int.MIN_VALUE, Int.MAX_VALUE - Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMin.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMaxMinusMin.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMin.gameField))
+        assertTrue(gameMaxMinusMin.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameMaxMinusMin.gameField.sideLength)
         println(Int.MAX_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE + Int.MAX_VALUE = -1 which is obvious
         val gameMinPlusMax = GameSession(Int.MIN_VALUE + Int.MAX_VALUE, Int.MIN_VALUE + Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMax.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMinPlusMax.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMax.gameField))
+        assertTrue(gameMinPlusMax.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameMinPlusMax.gameField.sideLength)
         println(Int.MIN_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MIN_VALUE = -1 which is obvious
         val gameMaxPlusMin = GameSession(Int.MAX_VALUE + Int.MIN_VALUE, Int.MAX_VALUE + Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMin.gameField.prepareForPrintingIn2d()}")
-        assertTrue(isGameFieldReady(gameMaxPlusMin.gameField))
-        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMin.gameField))
+        assertTrue(gameMaxPlusMin.gameField.isReady())
+        assertEquals(MIN_GAME_FIELD_SIDE_SIZE, gameMaxPlusMin.gameField.sideLength)
         println(Int.MAX_VALUE + Int.MIN_VALUE)
     }
 

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -22,7 +22,7 @@ class InternalElementsTesting {
 
     @Test
     fun gameIsNotStarted_classic3x3GameIsCreated_classic3x3GameFieldIsReady() {
-        val game = prepareClassic3x3GameField()
+        val game = GameSession(3, 3, 2)
         assertTrue(isGameFieldReady(game.gameField))
     }
 
@@ -192,7 +192,7 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_2AdjacentMarksAreSetByTheSamePlayer_detectedLineLengthIsCorrect() {
-        val game = prepareClassic3x3GameField()
+        val game = GameSession(3, 3, 2)
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
         val playerX = PlayerProvider.playersList[0]
@@ -209,7 +209,7 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_2RemoteMarksAreSetByTheSamePlayer_detectedLineLengthIsCorrect() {
-        val game = prepareClassic3x3GameField()
+        val game = GameSession(3, 3, 2)
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
         val playerX = PlayerProvider.playersList[0]
@@ -226,7 +226,7 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_2RemoteMarksOfTheSamePlayerAreConnected_detectedLineLengthIsCorrect() {
-        val game = prepareClassic3x3GameField()
+        val game = GameSession(3, 3, 2)
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
         val connectingMark = Coordinates(1, 0)
@@ -245,7 +245,7 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_2AdjacentMarksOfTheSamePlayerAreAddedWithOneMoreMark_detectedLineLengthIsCorrect() {
-        val game = prepareClassic3x3GameField()
+        val game = GameSession(3, 3, 2)
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
         val oneMoreMark = Coordinates(2, 0)
@@ -264,7 +264,7 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_2AdjacentMarksAreSetByDifferentPlayers_noLineIsCreatedForAnyPlayer() {
-        val game = prepareClassic3x3GameField()
+        val game = GameSession(3, 3, 2)
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
         val firstActivePlayer = PlayerProvider.activePlayer // should be player A
@@ -284,7 +284,7 @@ class InternalElementsTesting {
 
     @Test
     fun havingOneMarkSetForOnePlayerOn3x3Field_TryToSetMarkForAnotherPlayerInTheSamePlace_previousMarkRemainsUnchanged() {
-        val game = prepareClassic3x3GameField()
+        val game = GameSession(3, 3, 2)
         val someSpot = Coordinates(1, 1)
         val playerX = PlayerProvider.playersList[0]
         val playerO = PlayerProvider.playersList[1]

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -4,7 +4,6 @@ import elements.MAX_GAME_FIELD_SIDE_SIZE
 import elements.MIN_GAME_FIELD_SIDE_SIZE
 import logic.GameSession
 import logic.PlayerProvider
-import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -285,13 +284,13 @@ class InternalElementsTesting {
     @Test
     fun havingOneMarkSetForOnePlayerOn3x3Field_TryToSetMarkForAnotherPlayerInTheSamePlace_previousMarkRemainsUnchanged() {
         val game = GameSession(3, 3, 2)
-        val someSpot = Coordinates(1, 1)
+        val theSameSpot = Coordinates(1, 1)
         val playerX = PlayerProvider.playersList[0]
         val playerO = PlayerProvider.playersList[1]
-        game.makeMove(someSpot, playerX)
-        game.makeMove(someSpot, playerO)
+        game.makeMove(theSameSpot, playerX)
+        game.makeMove(theSameSpot, playerO)
         Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
-        assertEquals(playerX, game.gameField.getCurrentMarkAt(1, 1))
+        assertEquals(playerX, game.gameField.getCurrentMarkAt(theSameSpot.x, theSameSpot.y))
     }
 
     @Test
@@ -309,17 +308,13 @@ class InternalElementsTesting {
 
     @Test
     fun having3x3Field_onlyOnePlayerMarksAreSet_victoryConditionIsCorrect() {
-        val atttGame = AtttGame.create(3, 3)
-        val game = atttGame as GameSession
+        val game = GameSession(3, 3, 2)
         val playerX = PlayerProvider.playersList[0]
         game.makeMove(Coordinates(0, 0), playerX)
         game.makeMove(Coordinates(1, 0), playerX)
-        Log.pl(game.getWinner().getMaxLineLength().toString())
-        Log.pl(game.getLeader().getMaxLineLength().toString())
         game.makeMove(Coordinates(2, 0), playerX)
         // gameField & winning message for player A is printed in the console
         assertEquals(playerX, game.getWinner())
-        Log.pl("3x3 playerX: ${game.getWinner().hashCode()}")
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 
@@ -335,7 +330,6 @@ class InternalElementsTesting {
         game.makeMove(Coordinates(4, 0), playerX)
         game.makeMove(Coordinates(2, 0), playerX) // intentionally placed here to connect 2 segments
         assertEquals(playerX, game.getWinner())
-        Log.pl("5x5 Player.A: ${game.getWinner().hashCode()}")
         assertEquals(5, game.getWinner().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/InternalElementsTesting.kt
@@ -28,7 +28,7 @@ class InternalElementsTesting {
 
     @Test
     fun gameIsNotStarted_gameFieldOfAnyCorrectSizeIsCreated_gameFieldWithSpecifiedSizeIsReady() {
-        val game = GameSession(7, 5)
+        val game = GameSession(7, 5, 2)
         Log.pl("\ngameEngine is ready having this field: ${game.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game.gameField))
         assertEquals(7, getGameFieldSideLength(game.gameField))
@@ -37,22 +37,22 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_tooSmallGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength = 2 -> game would have no sense in this case, the same as with field size of 1
-        val game2x2 = GameSession(2, 2)
+        val game2x2 = GameSession(2, 2, 2)
         Log.pl("\ngameEngine is ready having this field: ${game2x2.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game2x2.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game2x2.gameField))
         // size = maxLength = 0
-        val game0x0 = GameSession(0, 0)
+        val game0x0 = GameSession(0, 0, 2)
         Log.pl("\ngameEngine is ready having this field: ${game0x0.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game0x0.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game0x0.gameField))
         // size = maxLength = -1
-        val gameM1M1 = GameSession(-1, -1)
+        val gameM1M1 = GameSession(-1, -1, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameM1M1.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameM1M1.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameM1M1.gameField))
         // size = maxLength = Int.MIN_VALUE
-        val gameMxM = GameSession(Int.MIN_VALUE, Int.MIN_VALUE)
+        val gameMxM = GameSession(Int.MIN_VALUE, Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMxM.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMxM.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMxM.gameField))
@@ -61,12 +61,12 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_tooBigGameFieldIsCreated_maximal1000x1000GameFieldIsReady() {
         // size = maxLength = 1001 -> for now the limit is set to 1000 dots per side but in the future there could be more
-        val game1k1 = GameSession(1001, 1001)
+        val game1k1 = GameSession(1001, 1001, 2)
         Log.pl("\ngameEngine is ready having this field: ${game1k1.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game1k1.gameField))
         assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game1k1.gameField))
         // size = maxLength = Int.MAX_VALUE
-        val gameMM = GameSession(Int.MAX_VALUE, Int.MAX_VALUE)
+        val gameMM = GameSession(Int.MAX_VALUE, Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMM.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMM.gameField))
         assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMM.gameField))
@@ -76,7 +76,7 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_underMinIntGameFieldIsCreated_maximal1000x1000GameFieldIsReady() {
         // size = maxLength tries to be less than Int.MIN_VALUE -> there will be overflow of the Int
-        val game = GameSession(Int.MIN_VALUE - 1, Int.MIN_VALUE - 1)
+        val game = GameSession(Int.MIN_VALUE - 1, Int.MIN_VALUE - 1, 2)
         Log.pl("\ngameEngine is ready having this field: ${game.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game.gameField))
         assertEquals(MAX_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
@@ -86,7 +86,7 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_overMaxIntGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength tries to be more than Int.MAX_VALUE -> there will be overflow of the Int
-        val game = GameSession(Int.MAX_VALUE + 1, Int.MAX_VALUE + 1)
+        val game = GameSession(Int.MAX_VALUE + 1, Int.MAX_VALUE + 1, 2)
         Log.pl("\ngameEngine is ready having this field: ${game.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(game.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(game.gameField))
@@ -97,56 +97,56 @@ class InternalElementsTesting {
     @Test
     fun gameIsNotStarted_MinAndMaxIntMixedGameFieldIsCreated_minimal3x3GameFieldIsReady() {
         // size = maxLength = Int.MIN_VALUE + Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
-        val gameMinPlusMin = GameSession(Int.MIN_VALUE + Int.MIN_VALUE, Int.MIN_VALUE + Int.MIN_VALUE)
+        val gameMinPlusMin = GameSession(Int.MIN_VALUE + Int.MIN_VALUE, Int.MIN_VALUE + Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMin.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinPlusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMin.gameField))
         println(Int.MIN_VALUE + Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MIN_VALUE = 0 in fact - this is an interesting effect of the Int
-        val gameMinMinusMin = GameSession(Int.MIN_VALUE - Int.MIN_VALUE, Int.MIN_VALUE - Int.MIN_VALUE)
+        val gameMinMinusMin = GameSession(Int.MIN_VALUE - Int.MIN_VALUE, Int.MIN_VALUE - Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMin.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinMinusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMin.gameField))
         println(Int.MIN_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MAX_VALUE = -2 in fact - this is an interesting effect of the Int
-        val gameMaxPlusMax = GameSession(Int.MAX_VALUE + Int.MAX_VALUE, Int.MAX_VALUE + Int.MAX_VALUE)
+        val gameMaxPlusMax = GameSession(Int.MAX_VALUE + Int.MAX_VALUE, Int.MAX_VALUE + Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMax.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxPlusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMax.gameField))
         println(Int.MAX_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MAX_VALUE = 0 which is obvious
-        val gameMaxMinusMax = GameSession(Int.MAX_VALUE - Int.MAX_VALUE, Int.MAX_VALUE - Int.MAX_VALUE)
+        val gameMaxMinusMax = GameSession(Int.MAX_VALUE - Int.MAX_VALUE, Int.MAX_VALUE - Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMax.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxMinusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMax.gameField))
         println(Int.MAX_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MIN_VALUE - Int.MAX_VALUE = +1 in fact - this is an interesting effect of the Int
-        val gameMinMinusMax = GameSession(Int.MIN_VALUE - Int.MAX_VALUE, Int.MIN_VALUE - Int.MAX_VALUE)
+        val gameMinMinusMax = GameSession(Int.MIN_VALUE - Int.MAX_VALUE, Int.MIN_VALUE - Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMinMinusMax.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinMinusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinMinusMax.gameField))
         println(Int.MIN_VALUE - Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE - Int.MIN_VALUE = -1 which is obvious
-        val gameMaxMinusMin = GameSession(Int.MAX_VALUE - Int.MIN_VALUE, Int.MAX_VALUE - Int.MIN_VALUE)
+        val gameMaxMinusMin = GameSession(Int.MAX_VALUE - Int.MIN_VALUE, Int.MAX_VALUE - Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxMinusMin.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxMinusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxMinusMin.gameField))
         println(Int.MAX_VALUE - Int.MIN_VALUE)
 
         // size = maxLength = Int.MIN_VALUE + Int.MAX_VALUE = -1 which is obvious
-        val gameMinPlusMax = GameSession(Int.MIN_VALUE + Int.MAX_VALUE, Int.MIN_VALUE + Int.MAX_VALUE)
+        val gameMinPlusMax = GameSession(Int.MIN_VALUE + Int.MAX_VALUE, Int.MIN_VALUE + Int.MAX_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMinPlusMax.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMinPlusMax.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMinPlusMax.gameField))
         println(Int.MIN_VALUE + Int.MAX_VALUE)
 
         // size = maxLength = Int.MAX_VALUE + Int.MIN_VALUE = -1 which is obvious
-        val gameMaxPlusMin = GameSession(Int.MAX_VALUE + Int.MIN_VALUE, Int.MAX_VALUE + Int.MIN_VALUE)
+        val gameMaxPlusMin = GameSession(Int.MAX_VALUE + Int.MIN_VALUE, Int.MAX_VALUE + Int.MIN_VALUE, 2)
         Log.pl("\ngameEngine is ready having this field: ${gameMaxPlusMin.gameField.prepareForPrintingIn2d()}")
         assertTrue(isGameFieldReady(gameMaxPlusMin.gameField))
         assertEquals(MIN_GAME_FIELD_SIDE_SIZE, getGameFieldSideLength(gameMaxPlusMin.gameField))
@@ -195,8 +195,9 @@ class InternalElementsTesting {
         val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
-        game.makeMove(firstMark, PlayerProvider.X)
-        game.makeMove(secondMark, PlayerProvider.X)
+        val playerX = PlayerProvider.playersList[0]
+        game.makeMove(firstMark, playerX)
+        game.makeMove(secondMark, playerX)
         game.printCurrentFieldIn2d()
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
@@ -211,8 +212,9 @@ class InternalElementsTesting {
         val game = prepareClassic3x3GameField()
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
-        game.makeMove(firstMark, PlayerProvider.X)
-        game.makeMove(secondMark, PlayerProvider.X)
+        val playerX = PlayerProvider.playersList[0]
+        game.makeMove(firstMark, playerX)
+        game.makeMove(secondMark, playerX)
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
@@ -228,9 +230,10 @@ class InternalElementsTesting {
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(2, 0)
         val connectingMark = Coordinates(1, 0)
-        game.makeMove(firstMark, PlayerProvider.X)
-        game.makeMove(secondMark, PlayerProvider.X)
-        game.makeMove(connectingMark, PlayerProvider.X)
+        val playerX = PlayerProvider.playersList[0]
+        game.makeMove(firstMark, playerX)
+        game.makeMove(secondMark, playerX)
+        game.makeMove(connectingMark, playerX)
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromFirstToSecond = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
@@ -246,9 +249,10 @@ class InternalElementsTesting {
         val firstMark = Coordinates(0, 0)
         val secondMark = Coordinates(1, 0)
         val oneMoreMark = Coordinates(2, 0)
-        game.makeMove(firstMark, PlayerProvider.X)
-        game.makeMove(secondMark, PlayerProvider.X)
-        game.makeMove(oneMoreMark, PlayerProvider.X)
+        val playerX = PlayerProvider.playersList[0]
+        game.makeMove(firstMark, playerX)
+        game.makeMove(secondMark, playerX)
+        game.makeMove(oneMoreMark, playerX)
         Log.pl("measuring line from $firstMark in the forward direction:")
         val lengthFromEdgeToEdge = game.gameField.measureLineFrom(firstMark, LineDirection.XpY0, 1)
         Log.pl("measuring line from $firstMark in the opposite direction:")
@@ -282,51 +286,56 @@ class InternalElementsTesting {
     fun havingOneMarkSetForOnePlayerOn3x3Field_TryToSetMarkForAnotherPlayerInTheSamePlace_previousMarkRemainsUnchanged() {
         val game = prepareClassic3x3GameField()
         val someSpot = Coordinates(1, 1)
-        game.makeMove(someSpot, PlayerProvider.X)
-        game.makeMove(someSpot, PlayerProvider.O)
+        val playerX = PlayerProvider.playersList[0]
+        val playerO = PlayerProvider.playersList[1]
+        game.makeMove(someSpot, playerX)
+        game.makeMove(someSpot, playerO)
         Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
-        assertEquals(PlayerProvider.X, game.gameField.getCurrentMarkAt(1, 1))
+        assertEquals(playerX, game.gameField.getCurrentMarkAt(1, 1))
     }
 
     @Test
     fun having3x3Field_TryToSetMarkForThisPlayerOnWrongPosition_currentPlayerRemainsUnchanged() {
-        val game = prepareClassic3x3GameField()
+        val game = GameSession(3, 3, 2)
+        val playerX = PlayerProvider.playersList[0]
+        val playerO = PlayerProvider.playersList[1]
         game.makeMove(-1, -1) // attempt to set the mark on a wrong place
-        assertEquals(PlayerProvider.X, PlayerProvider.activePlayer) // this player remains chosen for the next move
+        assertEquals(playerX, PlayerProvider.activePlayer) // this player remains chosen for the next move
         game.makeMove(1, 1) // another attempt for the same player - this time successful
-        assertEquals(PlayerProvider.O, PlayerProvider.activePlayer) // this time the next player is prepared for a move
+        assertEquals(playerO, PlayerProvider.activePlayer) // this time the next player is prepared for a move
         Log.pl("\ngame field with only one player's mark: ${game.gameField.prepareForPrintingIn2d()}")
-        assertEquals(PlayerProvider.X, game.gameField.getCurrentMarkAt(1, 1))
+        assertEquals(playerX, game.gameField.getCurrentMarkAt(1, 1))
     }
 
     @Test
     fun having3x3Field_onlyOnePlayerMarksAreSet_victoryConditionIsCorrect() {
-        println("having3x3Field_onlyOnePlayerMarksAreSet_victoryConditionIsCorrect")
         val atttGame = AtttGame.create(3, 3)
         val game = atttGame as GameSession
-        game.makeMove(Coordinates(0, 0), PlayerProvider.X)
-        game.makeMove(Coordinates(1, 0), PlayerProvider.X)
-        println(game.getWinner().getMaxLineLength())
-        println(game.getLeader().getMaxLineLength())
-        game.makeMove(Coordinates(2, 0), PlayerProvider.X)
+        val playerX = PlayerProvider.playersList[0]
+        game.makeMove(Coordinates(0, 0), playerX)
+        game.makeMove(Coordinates(1, 0), playerX)
+        Log.pl(game.getWinner().getMaxLineLength().toString())
+        Log.pl(game.getLeader().getMaxLineLength().toString())
+        game.makeMove(Coordinates(2, 0), playerX)
         // gameField & winning message for player A is printed in the console
-        assertEquals(PlayerProvider.X, game.getWinner())
-        println("3x3 Player.A: ${game.getWinner().hashCode()}")
+        assertEquals(playerX, game.getWinner())
+        Log.pl("3x3 playerX: ${game.getWinner().hashCode()}")
         assertEquals(3, game.getWinner().getMaxLineLength())
     }
 
     @Test
     fun having2LinesOfOnePlayerOn5x5Field_thisPlayerMarkIsSetInBetween_victoryConditionIsCorrect() {
-        val game = GameSession(5, 5)
+        val game = GameSession(5, 5, 2)
+        val playerX = PlayerProvider.playersList[0]
         Log.pl("\ntest5x5Field: gameEngine ready with given field: ${game.gameField.prepareForPrintingIn2d()}")
-        game.makeMove(Coordinates(0, 0), PlayerProvider.X)
-        game.makeMove(Coordinates(1, 0), PlayerProvider.X)
+        game.makeMove(Coordinates(0, 0), playerX)
+        game.makeMove(Coordinates(1, 0), playerX)
         // GameEngine.makeNewMove(Coordinates(2, 0), WhichPlayer.A) // intentionally commented - it will be used a bit later
-        game.makeMove(Coordinates(3, 0), PlayerProvider.X)
-        game.makeMove(Coordinates(4, 0), PlayerProvider.X)
-        game.makeMove(Coordinates(2, 0), PlayerProvider.X) // intentionally placed here to connect 2 segments
-        assertEquals(PlayerProvider.X, game.getWinner())
-        println("5x5 Player.A: ${game.getWinner().hashCode()}")
+        game.makeMove(Coordinates(3, 0), playerX)
+        game.makeMove(Coordinates(4, 0), playerX)
+        game.makeMove(Coordinates(2, 0), playerX) // intentionally placed here to connect 2 segments
+        assertEquals(playerX, game.getWinner())
+        Log.pl("5x5 Player.A: ${game.getWinner().hashCode()}")
         assertEquals(5, game.getWinner().getMaxLineLength())
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
@@ -1,3 +1,4 @@
+import elements.MAX_NUMBER_OF_PLAYERS
 import logic.PlayerProvider
 import publicApi.AtttGame
 import utilities.Log
@@ -93,7 +94,7 @@ class PublicApiTesting {
     // kind of a load testing on a field that is big and yet still able to fit into console output
     @Test
     fun having100x100Field_2PlayersMakeRandomMoves_activePlayerDefinitionForEachMoveIsCorrect() {
-        val game = AtttGame.create(100, 10, 42)
+        val game = AtttGame.create(100, 10, MAX_NUMBER_OF_PLAYERS)
         Log.switch(false) // speeding up and preventing from huge amount of messages in the console
         var iterationsCount = 0
         (0..999_999).forEach { _ -> // including ,so it's precisely a million in fact

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
@@ -67,4 +67,26 @@ class PublicApiTesting {
         assertEquals(3, game.getLeader().getMaxLineLength())
         game.printCurrentFieldIn2d()
     }
+
+    @Test
+    fun having4x4Field_3PlayersMakeCorrectMoves_activePlayerDefinitionForEachMoveIsCorrect() {
+        val game = AtttGame.create(4, 4, 3)
+        /*
+            A B C .
+            A B C .
+            A . . .
+            . . . .
+         */
+        game.mm(0, 0) // A
+        game.mm(1, 0) // B
+        game.mm(2, 0) // C
+        game.mm(0, 1) // A -> now A has a line of 2 marks and becomes a leader
+        game.mm(1, 1) // B -> now B also has a line of 2 marks
+        game.mm(2, 1) // C -> now C also has a line of 2 marks
+        game.mm(0, 2) // A -> now A has a line of 3 marks and becomes a new leader
+        game.printCurrentFieldIn2d()
+        assertEquals(PlayerProvider.playersList[0], game.getLeader())
+        assertEquals(3, game.getLeader().getMaxLineLength())
+    }
+
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
@@ -1,4 +1,5 @@
 import logic.PlayerProvider
+import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -17,7 +18,7 @@ class PublicApiTesting {
 
     @Test
     fun having3x3Field_onePlayerGetsMultiplePossibleLines_winnerIsDetectedOnceTheConditionsAreMet() {
-        val game = prepareGameInstanceForClassic3x3GameField()
+        val game = AtttGame.create(3, 3)
         /*
             . X x
             . x o
@@ -30,37 +31,40 @@ class PublicApiTesting {
         game.mm(1, 2) // X
         game.mm(2, 2) // O
         game.mm(1, 0) // X - this one was problematic but in version 0.3.0 this bug was fixed
-
+        val playerX = PlayerProvider.playersList[0]
         assertTrue(game.isGameWon(), "Game should have been won")
-        assertEquals(PlayerProvider.X, game.getWinner())
+        assertEquals(playerX, game.getWinner())
     }
 
     @Test
     fun having3x3Field_onePlayerMakesTheFirstLine_leadingPlayerIsDetectedCorrectly() {
-        val game = prepareGameInstanceForClassic3x3GameField()
-        game.mm(0, 0) // A
-        game.mm(1, 0) // B
-        game.mm(0, 1) // A -> now A has a line of 2 marks
-        assertEquals(PlayerProvider.X, game.getLeader())
+        val game = AtttGame.create(3, 3)
+        game.mm(0, 0) // X
+        game.mm(1, 0) // O
+        game.mm(0, 1) // X -> now A has a line of 2 marks
+        val playerX = PlayerProvider.playersList[0]
+        assertEquals(playerX, game.getLeader())
         assertEquals(2, game.getLeader().getMaxLineLength())
     }
 
     @Test
-    fun having5x5Field_onePlayerMakesLongerLineThanAnother_thisPlayerBecomesTheLeadingOne() {
+    fun having4x4Field_onePlayerMakesLongerLineThanAnother_thisPlayerBecomesTheLeadingOne() {
+        val game = AtttGame.create(4, 4)
         /*
             A B A .
             A B . .
             . B . .
             . . . .
          */
-        val game = prepareGameInstanceForClassic3x3GameField()
-        game.mm(0, 0) // A
-        game.mm(1, 0) // B
-        game.mm(0, 1) // A -> now A has a line of 2 marks and becomes a leader
-        game.mm(1, 1) // B -> now B also has a line of 2 marks
-        game.mm(2, 0) // A -> now A still has a line of 2 marks
-        game.mm(1, 2) // A -> now B has a line of 3 marks and becomes a new leader
-        assertEquals(PlayerProvider.O, game.getLeader())
+        game.mm(0, 0) // X
+        game.mm(1, 0) // O
+        game.mm(0, 1) // X -> now A has a line of 2 marks and becomes a leader
+        game.mm(1, 1) // O -> now B also has a line of 2 marks
+        game.mm(2, 0) // X -> now A still has a line of 2 marks
+        game.mm(1, 2) // O -> now B has a line of 3 marks and becomes a new leader
+        val playerO = PlayerProvider.playersList[1]
+        assertEquals(playerO.getId(), game.getLeader().getId())
         assertEquals(3, game.getLeader().getMaxLineLength())
+        game.printCurrentFieldIn2d()
     }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/PublicApiTesting.kt
@@ -1,6 +1,7 @@
 import logic.PlayerProvider
 import publicApi.AtttGame
 import utilities.Log
+import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -89,4 +90,23 @@ class PublicApiTesting {
         assertEquals(3, game.getLeader().getMaxLineLength())
     }
 
+    // kind of a load testing on a field that is big and yet still able to fit into console output
+    @Test
+    fun having100x100Field_2PlayersMakeRandomMoves_activePlayerDefinitionForEachMoveIsCorrect() {
+        val game = AtttGame.create(100, 10, 42)
+        Log.switch(false) // speeding up and preventing from huge amount of messages in the console
+        var iterationsCount = 0
+        (0..999_999).forEach { _ -> // including ,so it's precisely a million in fact
+            if (!game.isGameWon()) {
+                game.mm(Random.nextInt(100), Random.nextInt(100))
+                iterationsCount++
+            }
+        }
+        Log.switch(true) // restoring for possible other tests
+        Log.pl("iterationsCount: $iterationsCount")
+        Log.pl(
+            "player ${game.getLeader().getName()} is leading with maxLineLength: ${game.getLeader().getMaxLineLength()}"
+        )
+        game.printCurrentFieldIn2d()
+    }
 }

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
@@ -3,7 +3,6 @@ import elements.Coordinates
 import elements.LineDirection
 import logic.GameField
 import logic.GameSession
-import publicApi.AtttGame
 import utilities.Log
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -24,7 +23,7 @@ internal fun checkTheNextSpotDetectionBlock(startSpot: Coordinates) {
 
 internal fun checkTheNextSpotDetectionForLineDirection(startSpot: Coordinates, direction: LineDirection) {
     // as gameField is a stateful object - we have to reset it every time before a new test
-    val game = prepareClassic3x3GameField()
+    val game = GameSession(3, 3, 2)
     val nextSpot = game.gameField.getTheNextSafeSpaceFor(startSpot, direction)
     Log.pl("nextSpot on 3x3 field for $direction is $nextSpot")
     when {
@@ -47,21 +46,6 @@ internal fun checkTheNextSpotDetectionForLineDirection(startSpot: Coordinates, d
             assertTrue(nextSpot is Coordinates)
         }
     }
-}
-
-internal fun prepareClassic3x3GameField(): GameSession {
-    // using internal API here instead of AtttGame as this function is used inside group of tests in InternalApiTesting
-    val game3x3 = GameSession(3, 3)
-    Log.pl("\nprepareClassic3x3GameField: gameEngine is ready having this field: ${game3x3.gameField.prepareForPrintingIn2d()}")
-    return game3x3
-}
-
-// should use only publicly available API
-internal fun prepareGameInstanceForClassic3x3GameField(): AtttGame {
-    val gameInstance = AtttGame.create(3, 3)
-    Log.pl("\nprepareGameInstanceForClassic3x3GameField: gameInstance is ready having this field:")
-    gameInstance.printCurrentFieldIn2d()
-    return gameInstance
 }
 
 internal fun isGameFieldReady(gameField: GameField?) = gameField?.isReady() == true

--- a/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
+++ b/Attt_LocalEngine_Kotlin/src/test/kotlin/TestHelpers.kt
@@ -1,7 +1,6 @@
 import elements.Border
 import elements.Coordinates
 import elements.LineDirection
-import logic.GameField
 import logic.GameSession
 import utilities.Log
 import kotlin.test.assertEquals
@@ -47,7 +46,3 @@ internal fun checkTheNextSpotDetectionForLineDirection(startSpot: Coordinates, d
         }
     }
 }
-
-internal fun isGameFieldReady(gameField: GameField?) = gameField?.isReady() == true
-
-internal fun getGameFieldSideLength(gameField: GameField?) = gameField?.sideLength ?: -1


### PR DESCRIPTION
for now, the number of players in one game is limited only by the number of available & good-looking symbols for printing these players' marks on the console.  it's 128 - 33 (non-UI symbols) - 4 (small & bad looking for easy reading) - 1 (the space) = 90.